### PR TITLE
LUTECE-1823 : Allow datastore keys inserted into templates to be message formats

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/datastore/DatastoreService.java
+++ b/src/java/fr/paris/lutece/portal/service/datastore/DatastoreService.java
@@ -36,6 +36,7 @@ package fr.paris.lutece.portal.service.datastore;
 import fr.paris.lutece.portal.business.datastore.DataEntity;
 import fr.paris.lutece.portal.business.datastore.DataEntityHome;
 import fr.paris.lutece.portal.service.cache.AbstractCacheableService;
+import fr.paris.lutece.portal.service.template.FreeMarkerTemplateService;
 import fr.paris.lutece.portal.service.util.AppLogService;
 import fr.paris.lutece.portal.service.util.AppPathService;
 import fr.paris.lutece.portal.service.util.NoDatabaseException;
@@ -53,8 +54,9 @@ public final class DatastoreService
 {
     public static final String VALUE_TRUE = "true";
     public static final String VALUE_FALSE = "false";
-    private static final Pattern PATTERN_DATASTORE_KEY = Pattern.compile( "#dskey\\{(.*?)\\}" );
-    private static final String VALUE_MISSING = "DS Value Missing";
+    private static final String DATASTORE_KEY = "dskey";
+    private static final Pattern PATTERN_DATASTORE_KEY = Pattern.compile( "#" + DATASTORE_KEY + "\\{(.*?)\\}" );
+    static final String VALUE_MISSING = "DS Value Missing";
     private static AbstractCacheableService _cache;
     private static boolean _bDatabase = true;
 
@@ -63,6 +65,14 @@ public final class DatastoreService
      */
     private DatastoreService(  )
     {
+    }
+
+    /**
+     * initialize the service
+     */
+    public static void init(  )
+    {
+    	FreeMarkerTemplateService.getInstance( ).setSharedVariable( DATASTORE_KEY, new DatastoreTemplateMethod( ) );
     }
 
     /**

--- a/src/java/fr/paris/lutece/portal/service/datastore/DatastoreTemplateMethod.java
+++ b/src/java/fr/paris/lutece/portal/service/datastore/DatastoreTemplateMethod.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2014, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.datastore;
+
+import java.util.Locale;
+
+import fr.paris.lutece.portal.service.template.AbstractMessageFormatTemplateMethod;
+
+public class DatastoreTemplateMethod extends AbstractMessageFormatTemplateMethod
+{
+
+	@Override
+	protected String getPattern( String key, Locale locale ) {
+		return DatastoreService.getDataValue( key, DatastoreService.VALUE_MISSING );
+	}
+
+}

--- a/src/java/fr/paris/lutece/portal/service/i18n/I18nTemplateMethod.java
+++ b/src/java/fr/paris/lutece/portal/service/i18n/I18nTemplateMethod.java
@@ -33,47 +33,15 @@
  */
 package fr.paris.lutece.portal.service.i18n;
 
-import java.util.List;
+import java.util.Locale;
 
-import freemarker.core.Environment;
-import freemarker.template.TemplateDateModel;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import freemarker.template.TemplateNumberModel;
-import freemarker.template.TemplateScalarModel;
+import fr.paris.lutece.portal.service.template.AbstractMessageFormatTemplateMethod;
 
-public class I18nTemplateMethod implements TemplateMethodModelEx
+public class I18nTemplateMethod extends AbstractMessageFormatTemplateMethod
 {
-
 	@Override
-	public Object exec(@SuppressWarnings("rawtypes") List arguments) throws TemplateModelException
+	protected String getPattern( String key, Locale locale )
 	{
-		int argsSize = arguments.size();
-		if (argsSize < 1)
-		{
-			throw new TemplateModelException("Must be called with at least one argument (the message key)");
-		}
-		String key = ((TemplateScalarModel)arguments.get(0)).getAsString();
-		Object[] args = new Object[argsSize - 1];
-		for (int i = 1; i < argsSize; i++)
-		{
-			TemplateModel arg = (TemplateModel) arguments.get(i);
-			if (arg instanceof TemplateScalarModel)
-			{
-				args[i-1] = ((TemplateScalarModel)arg).getAsString();
-			} else if (arg instanceof TemplateNumberModel)
-			{
-				args[i-1] = ((TemplateNumberModel)arg).getAsNumber();
-			} else if (arg instanceof TemplateDateModel)
-			{
-				args[i-1] = ((TemplateDateModel)arg).getAsDate();
-			} else
-			{
-				throw new TemplateModelException("Unsupported argument type : " + arg);
-			}
-		}
-		return I18nService.getLocalizedString(key, args, Environment.getCurrentEnvironment().getLocale());
+		return I18nService.getLocalizedString( key, locale );
 	}
-
 }

--- a/src/java/fr/paris/lutece/portal/service/init/AppInit.java
+++ b/src/java/fr/paris/lutece/portal/service/init/AppInit.java
@@ -131,6 +131,9 @@ public final class AppInit
             // Initializes the template services from the servlet context information
             AppTemplateService.init( PATH_TEMPLATES );
 
+            // Initializes the Datastore Service
+            DatastoreService.init(  );
+
             if ( strRealPath != null )
             {
                 // Initializes the properties download files containing the

--- a/src/java/fr/paris/lutece/portal/service/template/AbstractMessageFormatTemplateMethod.java
+++ b/src/java/fr/paris/lutece/portal/service/template/AbstractMessageFormatTemplateMethod.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2014, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.template;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Locale;
+
+import freemarker.core.Environment;
+import freemarker.template.TemplateDateModel;
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import freemarker.template.TemplateNumberModel;
+import freemarker.template.TemplateScalarModel;
+
+public abstract class AbstractMessageFormatTemplateMethod implements TemplateMethodModelEx
+{
+
+	@Override
+	public Object exec( @SuppressWarnings("rawtypes") List arguments ) throws TemplateModelException
+	{
+		int argsSize = arguments.size( );
+		if ( argsSize < 1 )
+		{
+			throw new TemplateModelException( "Must be called with at least one argument (the message key)" );
+		}
+		String key = ( ( TemplateScalarModel ) arguments.get( 0 ) ).getAsString( );
+		Object[] args = new Object[argsSize - 1];
+		for ( int i = 1; i < argsSize; i++ )
+		{
+			TemplateModel arg = ( TemplateModel ) arguments.get( i );
+			if ( arg instanceof TemplateScalarModel )
+			{
+				args[i-1] = ( ( TemplateScalarModel ) arg ).getAsString( );
+			} else if ( arg instanceof TemplateNumberModel )
+			{
+				args[i-1] = ( ( TemplateNumberModel ) arg ).getAsNumber( );
+			} else if ( arg instanceof TemplateDateModel )
+			{
+				args[i-1] = ( ( TemplateDateModel ) arg ).getAsDate( );
+			} else
+			{
+				throw new TemplateModelException( "Unsupported argument type : " + arg ) ;
+			}
+		}
+		return MessageFormat.format( getPattern( key, Environment.getCurrentEnvironment( ).getLocale( ) ), args );
+	}
+
+	protected abstract String getPattern( String key, Locale locale );
+
+}


### PR DESCRIPTION
Extract the code of I18nTemplateMethod.java into a common abstract class.
Add an implementation that gets the message format from the datastore.
Register the shared dskey variable with the template service.

One can now use the following construct in templates:

${dskey(key,arg1,arg2,...)}
