### PR TITLE
LUTECE-1825 : fix init,upgrade script for postgres

### DIFF
--- a/src/sql/build.properties
+++ b/src/sql/build.properties
@@ -57,7 +57,7 @@ regexp.oracle.6=LONG VARCHAR
 replace.oracle.6=CLOB
 
 # Replacement rules for PostgreSQL
-regexp.postgresql.list=1,2,3,4,5,6,7
+regexp.postgresql.list=1,2,3,4,5,6,7,8
 regexp.postgresql.1=default '0000-00-00' NOT NULL
 replace.postgresql.1=
 regexp.postgresql.2=default '0000-00-00 00:00:00' NOT NULL
@@ -72,3 +72,5 @@ regexp.postgresql.6=([,(]) 0x([0-9A-F ]+)
 replace.postgresql.6=\\1decode('\\2', 'hex')
 regexp.postgresql.7=([source =]) 0x([0-9A-F ]+)
 replace.postgresql.7=\\1decode('\\1', 'hex')
+regexp.postgresql.8=/\\*E\\*/('.*')
+replace.postgresql.8=E\\1

--- a/src/sql/init_db_lutece_core.sql
+++ b/src/sql/init_db_lutece_core.sql
@@ -157,7 +157,7 @@ INSERT INTO core_datastore VALUES ('core.advanced_parameters.default_user_level'
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.default_user_notification', '1');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.default_user_language', 'fr');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.default_user_status', '0');
-INSERT INTO core_datastore VALUES ("core.advanced_parameters.email_pattern", "^[\\w_.\\-!\\#\\$\\%\\&\\\'\\*\\+\\/\\=\\?\\^\\\`\\}\\{\\|\\~]+@[\\w_.\\-]+\\.[\\w]+$");
+INSERT INTO core_datastore VALUES ('core.advanced_parameters.email_pattern', /*E*/'^[\\w_.\\-!\\#\\$\\%\\&''\\*\\+\\/\\=\\?\\^\\\`\\}\\{\\|\\~]+@[\\w_.\\-]+\\.[\\w]+$');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.email_pattern_verify_by', '');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.force_change_password_reinit', 'false');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.password_minimum_length', '8');

--- a/src/sql/upgrade/update_db_lutece_core-4.4.0-5.0.0.sql
+++ b/src/sql/upgrade/update_db_lutece_core-4.4.0-5.0.0.sql
@@ -9,7 +9,7 @@ INSERT INTO core_datastore VALUES ('core.advanced_parameters.default_user_level'
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.default_user_notification', '1');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.default_user_language', 'fr');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.default_user_status', '0');
-INSERT INTO core_datastore VALUES ("core.advanced_parameters.email_pattern", "^[\\w_.\\-!\\#\\$\\%\\&\\\'\\*\\+\\/\\=\\?\\^\\\`\\}\\{\\|\\~]+@[\\w_.\\-]+\\.[\\w]+$");
+INSERT INTO core_datastore VALUES ('core.advanced_parameters.email_pattern', /*E*/'^[\\w_.\\-!\\#\\$\\%\\&''\\*\\+\\/\\=\\?\\^\\\`\\}\\{\\|\\~]+@[\\w_.\\-]+\\.[\\w]+$');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.email_pattern_verify_by', '');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.force_change_password_reinit', 'false');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.password_minimum_length', '8');


### PR DESCRIPTION
Use ' as a string literal delimiter (and '' to escape ')
Add a substition for PostreSQL so that backslash escaping is
correctly interpreted.
An incorrect value is still injected for Oracle.
