### PR TITLE
LUTECE-1832 : Allow the I18n cache to be reset

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/i18n/I18nService.java
+++ b/src/java/fr/paris/lutece/portal/service/i18n/I18nService.java
@@ -514,4 +514,18 @@ public final class I18nService
 
         return rbLabels;
     }
+
+    /**
+     * Reset the caches
+     * @since 5.1
+     */
+    public static void resetCache(  )
+    {
+        ResourceBundle.clearCache(  );
+        if ( _overrideLoader != null)
+        {
+            ResourceBundle.clearCache( _overrideLoader );
+        }
+        _resourceBundleCache.clear(  );
+    }
 }

--- a/src/java/fr/paris/lutece/portal/web/system/CacheJspBean.java
+++ b/src/java/fr/paris/lutece/portal/web/system/CacheJspBean.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.portal.web.system;
 
 import fr.paris.lutece.portal.service.cache.CacheService;
 import fr.paris.lutece.portal.service.cache.CacheableService;
+import fr.paris.lutece.portal.service.i18n.I18nService;
 import fr.paris.lutece.portal.service.portal.PortalService;
 import fr.paris.lutece.portal.service.template.AppTemplateService;
 import fr.paris.lutece.portal.service.util.AppPropertiesService;
@@ -104,6 +105,7 @@ public class CacheJspBean extends AdminFeaturesPageJspBean
         {
             PortalService.resetCache(  );
             AppTemplateService.resetCache(  );
+            I18nService.resetCache();
         }
 
         return JSP_MANAGE_CACHES;

--- a/src/test/java/fr/paris/lutece/portal/service/i18n/I18nServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/i18n/I18nServiceTest.java
@@ -33,14 +33,23 @@
  */
 package fr.paris.lutece.portal.service.i18n;
 
-import fr.paris.lutece.test.LuteceTestCase;
-import fr.paris.lutece.util.ReferenceList;
-
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.SecureRandom;
 import java.text.DateFormat;
-
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Properties;
+
+import org.springframework.core.io.ClassPathResource;
+
+import fr.paris.lutece.test.LuteceTestCase;
+import fr.paris.lutece.util.ReferenceList;
 
 
 /**
@@ -135,5 +144,31 @@ public class I18nServiceTest extends LuteceTestCase
 
         ReferenceList result = fr.paris.lutece.portal.service.i18n.I18nService.getAdminLocales( locale );
         assertTrue( result.size(  ) >= 2 );
+    }
+
+    /**
+     * Test of resetCache method, of class fr.paris.lutece.portal.service.i18n.I18nService.
+     * @throws IOException
+     */
+    public void testResetCache(  ) throws IOException
+    {
+        // get a message
+        String message = I18nService.getLocalizedString( "portal.admin.admin_home.password", Locale.FRENCH );
+        // change the message
+        File propertiesFile = new ClassPathResource( "fr/paris/lutece/portal/resources/admin_messages_fr.properties" ).getFile(  ) ;
+        Properties resources = new Properties(  );
+        InputStream is = new FileInputStream( propertiesFile );
+        resources.load( is );
+        is.close(  );
+        String newValue = "junit" + new SecureRandom(  ).nextLong(  );
+        resources.setProperty( "admin_home.password", newValue );
+        OutputStream os = new FileOutputStream( propertiesFile );
+        resources.store( os, null );
+        os.close(  );
+        // read the value again
+        assertEquals( message, I18nService.getLocalizedString( "portal.admin.admin_home.password", Locale.FRENCH ) );
+        // clear the cache and read again
+        I18nService.resetCache(  );
+        assertEquals( newValue, I18nService.getLocalizedString( "portal.admin.admin_home.password", Locale.FRENCH ) );
     }
 }


### PR DESCRIPTION
Introduce a resetCache method in I18nService and hook it up in the reset all cache feature.
This allows to change i18n messages at run time.
