### PR TITLE
LUTECE-1871 : optimize PropertiesService#getPropertyInt

### DIFF
--- a/src/java/fr/paris/lutece/util/PropertiesService.java
+++ b/src/java/fr/paris/lutece/util/PropertiesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014, Mairie de Paris
+ * Copyright (c) 2002-2015, Mairie de Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+
+import org.apache.commons.lang.StringUtils;
 
 
 /**
@@ -201,8 +203,8 @@ public class PropertiesService
      * Returns the value of a variable defined in the .properties file of the application as an int
      *
      * @param strProperty The variable name
-     * @param nDefault The default value which is returned if no value is found for the variable in the le downloadFile
-     *        .properties. .properties file.
+     * @param nDefault The default value which is returned if no value is found for the variable in the
+     *        .properties file, or if the value is not numeric
      * @return The variable value read in the properties file
      */
     public int getPropertyInt( String strProperty, int nDefault )
@@ -212,7 +214,7 @@ public class PropertiesService
 
         try
         {
-            if ( ( strValue != null ) && strValue.matches( "^[\\d]+$" ) )
+            if ( StringUtils.isNumeric( strValue ) )
             {
                 nValue = Integer.parseInt( strValue );
             }


### PR DESCRIPTION
Use commons-lang StringUtils, which provides a numeric check
which does the null check too.

this improves the performance of the method by an order of magnitude.