### PR TITLE
LUTECE-1873 : When reloading all properties, construct a fresh Properties object

### DIFF
--- a/src/java/fr/paris/lutece/util/PropertiesService.java
+++ b/src/java/fr/paris/lutece/util/PropertiesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014, Mairie de Paris
+ * Copyright (c) 2002-2015, Mairie de Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,7 +54,7 @@ public class PropertiesService
 {
     // Static variables
     private static String _strRootPath;
-    private static Properties _properties = new Properties(  );
+    private static volatile Properties _properties = new Properties(  );
     private static Map<String, String> _mapPropertiesFiles = new HashMap<String, String>(  );
 
     /**
@@ -118,35 +118,21 @@ public class PropertiesService
      */
     private void loadFile( String strFullPath ) throws FileNotFoundException, IOException
     {
-        FileInputStream fis = null;
+        loadFile( strFullPath, _properties );
+    }
 
-        try
+    /**
+     * Load properties of a file
+     * @param strFullPath The absolute path of the properties file
+     * @param props properties to load into
+     * @throws java.io.IOException If an error occurs reading the file
+     * @throws java.io.FileNotFoundException If the file is not found
+     */
+    private void loadFile( String strFullPath, Properties props ) throws FileNotFoundException, IOException
+    {
+        try ( FileInputStream fis = new FileInputStream( new File( strFullPath ) ) )
         {
-            File file = new File( strFullPath );
-            fis = new FileInputStream( file );
-            _properties.load( fis );
-        }
-        catch ( FileNotFoundException fnfe )
-        {
-            throw fnfe;
-        }
-        catch ( IOException e )
-        {
-            throw e;
-        }
-        finally
-        {
-            if ( fis != null )
-            {
-                try
-                {
-                    fis.close(  );
-                }
-                catch ( IOException e )
-                {
-                    AppLogService.error( e.getMessage(  ), e );
-                }
-            }
+            props.load( fis );
         }
     }
 
@@ -167,10 +153,12 @@ public class PropertiesService
      */
     public void reloadAll(  ) throws IOException
     {
+        Properties newProperties = new Properties( );
         for ( String strFullPath : _mapPropertiesFiles.values(  ) )
         {
-            loadFile( strFullPath );
+            loadFile( strFullPath, newProperties );
         }
+        _properties = newProperties;
     }
 
     /**

--- a/src/test/java/fr/paris/lutece/util/PropertiesServiceTest.java
+++ b/src/test/java/fr/paris/lutece/util/PropertiesServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014, Mairie de Paris
+ * Copyright (c) 2002-2015, Mairie de Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,13 @@
  * License 1.0
  */
 package fr.paris.lutece.util;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Properties;
 
 import fr.paris.lutece.portal.service.util.AppPathService;
 import fr.paris.lutece.test.LuteceTestCase;
@@ -78,5 +85,37 @@ public class PropertiesServiceTest extends LuteceTestCase
 
         // Test reloading
         instance.reloadAll(  );
+    }
+
+    public void testReloadAll( ) throws FileNotFoundException, IOException
+    {
+        File propsFile = File.createTempFile( "junit", ".properties" );
+        propsFile.deleteOnExit( );
+
+        Properties props = new Properties( );
+        props.put( "test1", "test1" );
+        props.put( "test2", "test2" );
+        OutputStream os = new FileOutputStream( propsFile );
+        props.store( os, this.getClass( ).getName( ) );
+        os.close( );
+
+        PropertiesService instance = new PropertiesService( propsFile.getParent( ) );
+        instance.addPropertiesFile( "", propsFile.getName( ) );
+
+        for ( String key : props.stringPropertyNames( ) )
+        {
+            assertNotNull( instance.getProperty( key ) );
+            assertEquals( props.getProperty( key ), instance.getProperty( key ) );
+        }
+
+        props.setProperty( "test1", "test1_mod" );
+        props.remove( "test2" );
+        os = new FileOutputStream( propsFile );
+        props.store( os, this.getClass( ).getName( ) );
+        os.close( );
+
+        instance.reloadAll( );
+        assertEquals( props.getProperty( "test1" ), instance.getProperty( "test1" ) );
+        assertNull( instance.getProperty( "test2" ) );
     }
 }


### PR DESCRIPTION
Make _properties volatile so that the swap for the new object is atomic.
Add a test to verify that removed properties are absent after a reloadAll.