### PR TITLE
LUTECE-1877 : Use a LinkedHashMap to preserve the insertion order

### DIFF
--- a/src/java/fr/paris/lutece/util/PropertiesService.java
+++ b/src/java/fr/paris/lutece/util/PropertiesService.java
@@ -41,7 +41,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -57,7 +57,7 @@ public class PropertiesService
     // Static variables
     private static String _strRootPath;
     private static volatile Properties _properties = new Properties(  );
-    private static Map<String, String> _mapPropertiesFiles = new HashMap<String, String>(  );
+    private static Map<String, String> _mapPropertiesFiles = new LinkedHashMap<String, String>(  );
 
     /**
      * Constructor should define the base root path for properties files

--- a/src/test/java/fr/paris/lutece/util/PropertiesServiceTest.java
+++ b/src/test/java/fr/paris/lutece/util/PropertiesServiceTest.java
@@ -118,4 +118,41 @@ public class PropertiesServiceTest extends LuteceTestCase
         assertEquals( props.getProperty( "test1" ), instance.getProperty( "test1" ) );
         assertNull( instance.getProperty( "test2" ) );
     }
+
+    public void testReloadAllOrder( ) throws IOException
+    {
+        File propsFile = File.createTempFile( "junit", ".properties" );
+        propsFile.deleteOnExit( );
+
+        Properties props = new Properties( );
+        props.put( "key", "1" );
+        OutputStream os = new FileOutputStream( propsFile );
+        props.store( os, this.getClass( ).getName( ) );
+        os.close( );
+
+        PropertiesService instance = new PropertiesService( propsFile.getParent( ) );
+        instance.addPropertiesFile( "", propsFile.getName( ) );
+
+        assertEquals( "1", instance.getProperty( "key" ) );
+
+        for ( int i = 2; i < 10; i++ )
+        {
+            propsFile = File.createTempFile( "junit", ".properties" );
+            propsFile.deleteOnExit( );
+
+            props = new Properties( );
+            props.put( "key", Integer.toString( i ) );
+            os = new FileOutputStream( propsFile );
+            props.store( os, this.getClass( ).getName( ) );
+            os.close( );
+
+            instance.addPropertiesFile( "", propsFile.getName( ) );
+
+            assertEquals( Integer.toString( i ), instance.getProperty( "key" ) );
+
+            instance.reloadAll( );
+
+            assertEquals( Integer.toString( i ), instance.getProperty( "key" ) );
+        }
+    }
 }


### PR DESCRIPTION
Properties files are thus reloaded in the order they were added.
Add a test which fails without the patch.