### PR TITLE
Lutece 1878 : key the SiteMapApp cache on the user's roles

### DIFF
--- a/src/java/fr/paris/lutece/portal/web/xpages/SiteMapApp.java
+++ b/src/java/fr/paris/lutece/portal/web/xpages/SiteMapApp.java
@@ -49,12 +49,15 @@ import fr.paris.lutece.portal.service.util.AppPathService;
 import fr.paris.lutece.portal.web.admin.AdminPageJspBean;
 import fr.paris.lutece.util.xml.XmlUtil;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
 import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang.StringUtils;
 
 
 /**
@@ -153,7 +156,7 @@ public class SiteMapApp implements XPageApplication
      */
     private String getKey( int nMode, HttpServletRequest request )
     {
-        String strUser = "-";
+        String strRoles = "-";
 
         if ( SecurityService.isAuthenticationEnable(  ) )
         {
@@ -161,11 +164,13 @@ public class SiteMapApp implements XPageApplication
 
             if ( user != null )
             {
-                strUser = user.getName(  );
+                String[ ] roles = user.getRoles( );
+                Arrays.sort( roles );
+                strRoles = StringUtils.join( roles, ',' );
             }
         }
 
-        return "[m:" + nMode + "][user:" + strUser + "]";
+        return "[m:" + nMode + "][roles:" + strRoles + "]";
     }
 
     /**

--- a/src/test/java/fr/paris/lutece/portal/service/portal/PortalMenuServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/portal/PortalMenuServiceTest.java
@@ -41,19 +41,16 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Properties;
 import java.util.Random;
 
-import javax.security.auth.login.LoginException;
 import javax.servlet.http.HttpServletRequest;
 
 import fr.paris.lutece.portal.business.page.Page;
 import fr.paris.lutece.portal.service.init.LuteceInitException;
 import fr.paris.lutece.portal.service.page.IPageService;
-import fr.paris.lutece.portal.service.security.LoginRedirectException;
-import fr.paris.lutece.portal.service.security.LuteceAuthentication;
 import fr.paris.lutece.portal.service.security.LuteceUser;
+import fr.paris.lutece.portal.service.security.MokeLuteceAuthentication;
 import fr.paris.lutece.portal.service.security.SecurityService;
 import fr.paris.lutece.portal.service.spring.SpringContextService;
 import fr.paris.lutece.portal.service.util.AppPropertiesService;
@@ -238,7 +235,7 @@ public class PortalMenuServiceTest extends LuteceTestCase
             props.load( is );
             is.close( );
             props.setProperty( "mylutece.authentication.enable", "true" );
-            props.setProperty( "mylutece.authentication.class", TestLuteceAuthentication.class.getName( ) );
+            props.setProperty( "mylutece.authentication.class", MokeLuteceAuthentication.class.getName( ) );
             OutputStream os = new FileOutputStream( luteceProperties );
             props.store( os, "saved for junit " + this.getClass( ).getCanonicalName( ) );
             os.close( );
@@ -267,210 +264,4 @@ public class PortalMenuServiceTest extends LuteceTestCase
         return createPage( pageName, null );
     }
 
-    public static final class TestLuteceAuthentication implements LuteceAuthentication
-    {
-
-        @Override
-        public String getAuthServiceName( )
-        {
-            return this.getClass( ).getName( );
-        }
-
-        @Override
-        public String getAuthType( HttpServletRequest request )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public LuteceUser login( String strUserName, String strUserPassword, HttpServletRequest request )
-                throws LoginException, LoginRedirectException
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void logout( LuteceUser user )
-        {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public boolean findResetPassword( HttpServletRequest request, String strLogin )
-        {
-            // TODO Auto-generated method stub
-            return false;
-        }
-
-        @Override
-        public LuteceUser getAnonymousUser( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public boolean isUserInRole( LuteceUser user, HttpServletRequest request, String strRole )
-        {
-            return Arrays.asList( user.getRoles( ) ).contains( strRole );
-        }
-
-        @Override
-        public String[ ] getRolesByUser( LuteceUser user )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public boolean isExternalAuthentication( )
-        {
-            // TODO Auto-generated method stub
-            return false;
-        }
-
-        @Override
-        public boolean isDelegatedAuthentication( )
-        {
-            // TODO Auto-generated method stub
-            return false;
-        }
-
-        @Override
-        public LuteceUser getHttpAuthenticatedUser( HttpServletRequest request )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getLoginPageUrl( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getDoLoginUrl( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getDoLogoutUrl( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getNewAccountPageUrl( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getViewAccountPageUrl( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getLostPasswordPageUrl( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getLostLoginPageUrl( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getResetPasswordPageUrl( HttpServletRequest request )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getAccessDeniedTemplate( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getAccessControledTemplate( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public boolean isUsersListAvailable( )
-        {
-            // TODO Auto-generated method stub
-            return false;
-        }
-
-        @Override
-        public Collection<LuteceUser> getUsers( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public LuteceUser getUser( String strUserLogin )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public boolean isMultiAuthenticationSupported( )
-        {
-            // TODO Auto-generated method stub
-            return false;
-        }
-
-        @Override
-        public String getIconUrl( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getName( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String getPluginName( )
-        {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void updateDateLastLogin( LuteceUser user, HttpServletRequest request )
-        {
-            // TODO Auto-generated method stub
-
-        }
-
-    }
 }

--- a/src/test/java/fr/paris/lutece/portal/service/security/MokeLuteceAuthentication.java
+++ b/src/test/java/fr/paris/lutece/portal/service/security/MokeLuteceAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014, Mairie de Paris
+ * Copyright (c) 2002-2015, Mairie de Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.portal.service.security;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import javax.security.auth.login.LoginException;
@@ -82,7 +83,7 @@ public class MokeLuteceAuthentication implements LuteceAuthentication
 
     public boolean isUserInRole( LuteceUser user, HttpServletRequest request, String strRole )
     {
-        return true;
+        return Arrays.asList( user.getRoles( ) ).contains( strRole );
     }
 
     public String[] getRolesByUser( LuteceUser user )

--- a/src/test/java/fr/paris/lutece/portal/web/xpages/SiteMapAppTest.java
+++ b/src/test/java/fr/paris/lutece/portal/web/xpages/SiteMapAppTest.java
@@ -33,16 +33,30 @@
  */
 package fr.paris.lutece.portal.web.xpages;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.Random;
 
 import javax.servlet.http.HttpServletRequest;
 
 import fr.paris.lutece.portal.business.page.Page;
 import fr.paris.lutece.portal.business.style.PageTemplateHome;
+import fr.paris.lutece.portal.service.init.LuteceInitException;
 import fr.paris.lutece.portal.service.page.IPageService;
 import fr.paris.lutece.portal.service.plugin.Plugin;
 import fr.paris.lutece.portal.service.portal.PortalService;
+import fr.paris.lutece.portal.service.security.LuteceUser;
+import fr.paris.lutece.portal.service.security.MokeLuteceAuthentication;
+import fr.paris.lutece.portal.service.security.SecurityService;
 import fr.paris.lutece.portal.service.spring.SpringContextService;
+import fr.paris.lutece.portal.service.util.AppPropertiesService;
 import fr.paris.lutece.test.LuteceTestCase;
 import fr.paris.lutece.test.MokeHttpServletRequest;
 
@@ -101,4 +115,176 @@ public class SiteMapAppTest extends LuteceTestCase
         sitemap = instance.getPage( request, 0, null );
         assertFalse( "Site map should not contain page with name " + randomPageName + " anymore", sitemap.getContent( ).contains( randomPageName ) );
     }
+
+    private static final String ROLE1 = "ROLE1";
+    private static final String ROLE2 = "ROLE2";
+
+    public void testPageVisibility( ) throws IOException, LuteceInitException
+    {
+        // create pages
+        final Random rand = new SecureRandom( );
+        Page pageNoRole = createPage( "page." + rand.nextLong( ) );
+        Page pageRole1 = createPage( "page.role1." + rand.nextLong( ), ROLE1 );
+        Page pageRole2 = createPage( "page.role2." + rand.nextLong( ), ROLE2 );
+
+        boolean authStatus = enableAuthentication( );
+        boolean cacheStatus = enableSiteMapCacheService( );
+
+        try
+        {
+            SiteMapApp instance = new SiteMapApp(  );
+            // test twice to test the cache
+            for ( int i = 0; i < 2; i++ )
+            {
+                // test menu content with no role
+                HttpServletRequest request = new MokeHttpServletRequest( );
+                XPage sitemap = instance.getPage( request, 0, null );
+                assertTrue( "Site map should contain page not associated with a role named " + pageNoRole.getName( )
+                        + " (call " + ( i + 1 ) + ")", sitemap.getContent( ).contains( pageNoRole.getName( ) ) );
+                assertFalse( "Site map should not contain page associated with role " + ROLE1 + " named "
+                        + pageRole1.getName( ) + " (call " + ( i + 1 ) + ")", sitemap.getContent( ).contains( pageRole1.getName( ) ) );
+                assertFalse( "Site map should not contain page associated with role " + ROLE2 + " named "
+                        + pageRole2.getName( ) + " (call " + ( i + 1 ) + ")", sitemap.getContent( ).contains( pageRole2.getName( ) ) );
+
+                // test menu content with ROLE1
+                @SuppressWarnings( "serial" )
+                LuteceUser user = new LuteceUser( "junit", SecurityService.getInstance( ).getAuthenticationService( ) )
+                {
+
+                    @Override
+                    public String getName( )
+                    {
+                        // user name is different on each call
+                        return "user" + rand.nextLong( );
+                    }
+
+                };
+                user.setRoles( Arrays.asList( ROLE1 ) );
+                request.getSession( ).setAttribute( "lutece_user", user );
+                sitemap = instance.getPage( request, 0, null );
+                assertTrue( "Site map should contain page not associated with a role named " + pageNoRole.getName( )
+                        + " (call " + ( i + 1 ) + ")", sitemap.getContent( ).contains( pageNoRole.getName( ) ) );
+                assertTrue(
+                        "Site map should contain page associated with role " + ROLE1 + " named "
+                                + pageRole1.getName( ) + " (call " + ( i + 1 ) + ")",
+                         sitemap.getContent( ).contains( pageRole1.getName( ) ) );
+                assertFalse( "Site map should not contain page associated with role " + ROLE2 + " named "
+                        + pageRole2.getName( ) + " (call " + ( i + 1 ) + ")", sitemap.getContent( ).contains( pageRole2.getName( ) ) );
+
+                // test menu content with ROLE2
+                user.setRoles( Arrays.asList( ROLE2 ) );
+                sitemap = instance.getPage( request, 0, null );
+                assertTrue( "Site map should contain page not associated with a role named " + pageNoRole.getName( )
+                        + " (call " + ( i + 1 ) + ")", sitemap.getContent( ).contains( pageNoRole.getName( ) ) );
+                assertFalse( "Site map should not contain page associated with role " + ROLE1 + " named "
+                        + pageRole1.getName( ) + " (call " + ( i + 1 ) + ")", sitemap.getContent( ).contains( pageRole1.getName( ) ) );
+                assertTrue(
+                        "Site map should contain page associated with role " + ROLE2 + " named "
+                                + pageRole2.getName( ) + " (call " + ( i + 1 ) + ")",
+                        sitemap.getContent( ).contains( pageRole2.getName( ) ) );
+
+                // test menu content with ROLE1 and ROLE2
+                user.setRoles( Arrays.asList( ROLE1, ROLE2 ) );
+                sitemap = instance.getPage( request, 0, null );
+                assertTrue( "Site map should contain page not associated with a role named " + pageNoRole.getName( )
+                        + " (call " + ( i + 1 ) + ")", sitemap.getContent( ).contains( pageNoRole.getName( ) ) );
+                assertTrue(
+                        "Site map should contain page associated with role " + ROLE1 + " named "
+                                + pageRole1.getName( ) + " (call " + ( i + 1 ) + ")",
+                        sitemap.getContent( ).contains( pageRole1.getName( ) ) );
+                assertTrue(
+                        "Site map should contain page associated with role " + ROLE2 + " named "
+                                + pageRole2.getName( ) + " (call " + ( i + 1 ) + ")",
+                        sitemap.getContent( ).contains( pageRole2.getName( ) ) );
+
+                // test menu content with ROLE2 and ROLE1
+                user.setRoles( Arrays.asList( ROLE2, ROLE1 ) );
+                XPage sitemap2 = instance.getPage( request, 0, null );
+                assertTrue( "Role order should not matter to the cache (call " + ( i + 1 ) + ")", sitemap.getContent( ) == sitemap2.getContent( ) );
+            }
+        } finally
+        {
+            // cleanup
+            restoreAuthentication( authStatus );
+            restoreSiteMapCacheService( cacheStatus );
+
+            IPageService pageService = ( IPageService ) SpringContextService.getBean( "pageService" );
+            pageService.removePage( pageNoRole.getId( ) );
+            pageService.removePage( pageRole1.getId( ) );
+            pageService.removePage( pageRole2.getId( ) );
+        }
+    }
+
+    private void restoreSiteMapCacheService( boolean status )
+    {
+        SiteMapCacheService.getInstance( ).enableCache( status );
+    }
+
+    private boolean enableSiteMapCacheService( )
+    {
+        boolean status = SiteMapCacheService.getInstance( ).isCacheEnable( );
+        SiteMapCacheService.getInstance( ).enableCache( true );
+        return status;
+    }
+
+    private void restoreAuthentication( boolean status ) throws IOException, LuteceInitException
+    {
+        if ( !status )
+        {
+            File luteceProperties = new File( getResourcesDir( ), "WEB-INF/conf/lutece.properties" );
+            Properties props = new Properties( );
+            InputStream is = new FileInputStream( luteceProperties );
+            props.load( is );
+            is.close( );
+            props.remove( "mylutece.authentication.enable" );
+            props.remove( "mylutece.authentication.class" );
+            OutputStream os = new FileOutputStream( luteceProperties );
+            props.store( os, "saved for junit " + this.getClass( ).getCanonicalName( ) );
+            os.close( );
+            AppPropertiesService.reloadAll( );
+            SecurityService.init( );
+        }
+    }
+
+    private boolean enableAuthentication( ) throws IOException, LuteceInitException
+    {
+        boolean status = SecurityService.isAuthenticationEnable( );
+        if ( !status )
+        {
+            File luteceProperties = new File( getResourcesDir( ), "WEB-INF/conf/lutece.properties" );
+            Properties props = new Properties( );
+            InputStream is = new FileInputStream( luteceProperties );
+            props.load( is );
+            is.close( );
+            props.setProperty( "mylutece.authentication.enable", "true" );
+            props.setProperty( "mylutece.authentication.class", MokeLuteceAuthentication.class.getName( ) );
+            OutputStream os = new FileOutputStream( luteceProperties );
+            props.store( os, "saved for junit " + this.getClass( ).getCanonicalName( ) );
+            os.close( );
+            AppPropertiesService.reloadAll( );
+            SecurityService.init( );
+        }
+        return status;
+    }
+
+    private Page createPage( String pageName, String role )
+    {
+        Page page = new Page( );
+        page.setParentPageId( PortalService.getRootPageId( ) );
+        page.setName( pageName );
+        page.setPageTemplateId( PageTemplateHome.getPageTemplatesList( ).get( 0 ).getId( ) );
+        if ( role != null )
+        {
+            page.setRole( role );
+        }
+        IPageService pageService = ( IPageService ) SpringContextService.getBean( "pageService" );
+        pageService.createPage( page );
+        return page;
+    }
+
+    private Page createPage( String pageName )
+    {
+        return createPage( pageName, null );
+    }
+
 }


### PR DESCRIPTION
The SiteMapApp outputs pages whose visibility depends on the user's roles,
and not on her name. Keying the cache on the role list should improve significantly
the cache hit ratio when the site is accessed by authenticated users.

Add a test checking that page visibility is respected, and that the cache returns
the same page content for the same role combination. adapt and reuse MokeLuteceAuthentication.