### PR TITLE
LUTECE-1925 : Allow XPages to be set as disabled in the plugin description file

### DIFF
--- a/src/java/fr/paris/lutece/portal/resources/system_messages.properties
+++ b/src/java/fr/paris/lutece/portal/resources/system_messages.properties
@@ -141,6 +141,7 @@ view_plugin.boxTitlePortletsType=Portlets
 view_plugin.boxTitleXpageApplications=XPages
 view_plugin.boxTitleContentServices=Content services
 view_plugin.boxTitleInsertServices=Insert services
+view_plugin.disabled=disabled
 
 # Template manage_daemons
 manage_daemons.titleCacheList=List of daemons

--- a/src/java/fr/paris/lutece/portal/resources/system_messages_fr.properties
+++ b/src/java/fr/paris/lutece/portal/resources/system_messages_fr.properties
@@ -140,6 +140,7 @@ view_plugin.boxTitlePortletsType=Portlets
 view_plugin.boxTitleXpageApplications=Pages sp\u00e9ciales
 view_plugin.boxTitleContentServices=Services de contenu
 view_plugin.boxTitleInsertServices=Services d'insertion
+view_plugin.disabled=d\u00e9sactiv\u00e9
 
 # Template manage_daemons
 manage_daemons.titleCacheList=Liste des daemons

--- a/src/java/fr/paris/lutece/portal/service/content/XPageAppService.java
+++ b/src/java/fr/paris/lutece/portal/service/content/XPageAppService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014, Mairie de Paris
+ * Copyright (c) 2002-2015, Mairie de Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -106,7 +106,8 @@ public class XPageAppService extends ContentService
             }
 
             _mapApplications.put( entry.getId(  ), entry );
-            AppLogService.info( "New XPage application registered : " + entry.getId(  ) );
+            AppLogService.info( "New XPage application registered : " + entry.getId(  )
+                    + ( entry.isEnabled(  ) ? "" : " (disabled)" ) );
         }
         catch ( ClassNotFoundException e )
         {

--- a/src/java/fr/paris/lutece/portal/service/plugin/plugin-digester-rules.xml
+++ b/src/java/fr/paris/lutece/portal/service/plugin/plugin-digester-rules.xml
@@ -69,6 +69,7 @@
             <bean-property-setter-rule pattern="application-id" propertyname="id" />
             <bean-property-setter-rule pattern="application-class" propertyname="className" />
             <bean-property-setter-rule pattern="application-roles" propertyname="roles" />
+            <bean-property-setter-rule pattern="enabled" propertyname="enabled" />
             <set-next-rule methodname="addXPageApplication" />
         </pattern>
         <pattern value="filters/filter">

--- a/src/java/fr/paris/lutece/portal/web/xpages/XPageApplicationEntry.java
+++ b/src/java/fr/paris/lutece/portal/web/xpages/XPageApplicationEntry.java
@@ -52,6 +52,7 @@ public class XPageApplicationEntry
     private String _strClassName;
     private String _strPluginName;
     private List<String> _listRoles = new ArrayList<String>(  );
+    private boolean _bEnabled = true; // defaults to enabled
 
     /**
      * Returns the Id
@@ -170,7 +171,27 @@ public class XPageApplicationEntry
      */
     public boolean isEnable(  )
     {
-        return PluginService.isPluginEnable( _strPluginName );
+        return _bEnabled && PluginService.isPluginEnable( _strPluginName );
+    }
+
+    /**
+     * Tells if the XPageApplication is enabled, independently of the plugin's status
+     * @return <code>true</code> if this XPageApplication is enabled, <code>false</code> otherwise
+     * @since 5.1
+     */
+    public boolean isEnabled(  )
+    {
+        return _bEnabled;
+    }
+
+    /**
+     * Sets the enabled state of this XPageApplication
+     * @param enabled <code>true</code> if this XPageApplication is enabled, <code>false</code> otherwise
+     * @since 5.1
+     */
+    public void setEnabled( boolean bEnabled )
+    {
+        _bEnabled = bEnabled;
     }
 
     /**

--- a/src/test/java/fr/paris/lutece/portal/service/content/XPageAppServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/content/XPageAppServiceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2002-2015, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.content;
+
+import java.util.Collection;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import fr.paris.lutece.portal.service.init.LuteceInitException;
+import fr.paris.lutece.portal.service.message.SiteMessageException;
+import fr.paris.lutece.portal.service.plugin.Plugin;
+import fr.paris.lutece.portal.service.portal.PortalService;
+import fr.paris.lutece.portal.service.security.UserNotSignedException;
+import fr.paris.lutece.portal.web.xpages.XPage;
+import fr.paris.lutece.portal.web.xpages.XPageApplication;
+import fr.paris.lutece.portal.web.xpages.XPageApplicationEntry;
+import fr.paris.lutece.test.LuteceTestCase;
+
+
+public class XPageAppServiceTest extends LuteceTestCase
+{
+    public void testGetXPageApplicationsList(  )
+    {
+        Collection<XPageApplicationEntry> listXPageApps = XPageAppService.getXPageApplicationsList(  );
+        // Assert default XPages are loaded
+        assertTrue( listXPageApps.size(  ) >= 2 );
+    }
+
+    public void testEnabledState(  ) throws LuteceInitException
+    {
+        XPageApplicationEntry entry = new XPageApplicationEntry(  );
+        entry.setClassName( TestXPageApplication.class.getName(  ) );
+        entry.setId( "testEnableXPageApplication" );
+        entry.setPluginName( "core" ); // core is an always enabled plugin
+
+        XPageAppService.registerXPageApplication( entry );
+
+        assertTrue( isTestXPageApplicationActive( entry ) );
+
+        entry.setEnabled( false );
+        XPageAppService.registerXPageApplication( entry );
+        assertFalse( isTestXPageApplicationActive( entry ) );
+
+        entry.setPluginName( "bogus_inexistant_plugin" );
+        XPageAppService.registerXPageApplication( entry );
+        assertFalse( isTestXPageApplicationActive( entry ) );
+
+        entry.setEnabled( true );
+        XPageAppService.registerXPageApplication( entry );
+        assertFalse( isTestXPageApplicationActive( entry ) );
+    }
+
+    private boolean isTestXPageApplicationActive( XPageApplicationEntry entry )
+    {
+        MockHttpServletRequest request = new MockHttpServletRequest( );
+        request.addParameter( "page", entry.getId( ) );
+        ContentService cs = PortalService.getInvokedContentService( request );
+        try
+        {
+            cs.getPage( request, 0 );
+            return true;
+        } catch ( UserNotSignedException | SiteMessageException e )
+        {
+            return false;
+        }
+    }
+
+    @SuppressWarnings( "serial" )
+    static class TestXPageApplication implements XPageApplication
+    {
+
+        @Override
+        public XPage getPage( HttpServletRequest request, int nMode, Plugin plugin ) throws UserNotSignedException,
+                SiteMessageException
+        {
+            return new XPage( );
+        }
+    }
+}

--- a/webapp/WEB-INF/conf/core.xml
+++ b/webapp/WEB-INF/conf/core.xml
@@ -36,10 +36,12 @@
     <applications>
         <application>
             <application-id>search</application-id>
+            <enabled>${core.xpage.search.enabled}</enabled>
         </application>
         <application>
             <application-id>map</application-id>
             <application-class>fr.paris.lutece.portal.web.xpages.SiteMapApp</application-class>
+            <enabled>${core.xpage.map.enabled}</enabled>
         </application>
     </applications>
 

--- a/webapp/WEB-INF/conf/lutece.properties
+++ b/webapp/WEB-INF/conf/lutece.properties
@@ -280,3 +280,8 @@ core.include.links.enabled=true
 core.include.metas.enabled=true
 core.include.statistics.enabled=true
 core.include.themes.enabled=true
+
+################################################################################
+#### XPages activations
+core.xpage.search.enabled=true
+core.xpage.map.enabled=true

--- a/webapp/WEB-INF/templates/admin/system/view_plugin.html
+++ b/webapp/WEB-INF/templates/admin/system/view_plugin.html
@@ -75,8 +75,8 @@
 				<ul>
                     <#list applications as application >
                     <li>
-                        <h3>${application.id}</h3>
-                        <p>${application.className}</p>
+                        <h3>${application.id}<#if !application.enabled> <span class="badge"><i class="fa fa-ban"></i> ${i18n("portal.system.view_plugin.disabled")}</span></#if></h3>
+                        <p>${application.className!}</p>
                     </li>		
                     </#list>
                 </ul>

--- a/webapp/css/admin/portal_admin.css
+++ b/webapp/css/admin/portal_admin.css
@@ -225,6 +225,11 @@ ul.pagination{margin-top:0;}
 ----------------------------
 */
 .plugin{min-height:300px;max-height:300px;}
+/* 
+	Plugins view
+----------------------------
+*/
+h3>.badge { vertical-align: middle }
 
 /* 
 	Admin Site


### PR DESCRIPTION
This flag can be set via a property, thus it is not necessary to duplicate the
plugin's xml file, which has no override mechanism, to disable an XPage.