### PR TITLE
LUTECE-1933 : Experimental jade templating support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,12 @@
             <version>1.1.0</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>fr.paris.lutece.plugins</groupId>
+            <artifactId>library-jade</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
 		
         <!-- Workflow -->
         <dependency>

--- a/src/java/fr/paris/lutece/portal/service/template/AppTemplateService.java
+++ b/src/java/fr/paris/lutece/portal/service/template/AppTemplateService.java
@@ -45,7 +45,7 @@ import java.util.Locale;
 
 
 /**
- * This Service is used to retreive HTML templates, stored as files in the
+ * This Service is used to retrieve HTML templates, stored as files in the
  * WEB-INF/templates directory of the webapp,
  * to build the user interface. It provides a cache feature to prevent from
  * loading file each time it is asked.
@@ -55,6 +55,7 @@ public final class AppTemplateService
     // Variables
     private static String _strTemplateDefaultPath;
     private static IFreeMarkerTemplateService _freeMarkerTemplateService;
+    private static IJadeTemplateService _jadeTemplateService;
 
     /**
      * Protected constructor
@@ -71,6 +72,7 @@ public final class AppTemplateService
     {
         _strTemplateDefaultPath = strTemplatePath;
         getFreeMarkerTemplateService(  ).setSharedVariable( "i18n", new I18nTemplateMethod(  ) );
+        getFreeMarkerTemplateService(  ).setSharedVariable( "jade", new FreemarkerDirective( getJadeTemplateService(  ) ) );
     }
 
     /**
@@ -109,6 +111,7 @@ public final class AppTemplateService
     public static void resetCache(  )
     {
         getFreeMarkerTemplateService(  ).resetCache(  );
+        getJadeTemplateService(  ).resetCache(  );
     }
 
     /**
@@ -206,7 +209,7 @@ public final class AppTemplateService
      * Returns a reference on a template object
      *
      * <br />
-     * <b>Deprecated</b> Using Freemarker without cache is huge CPU consuming
+     * <b>Deprecated</b> Using Freemarker without cache is very CPU intensive
      *
      * @param strFreemarkerTemplateData The content of the template
      * @param locale The current {@link Locale} to localize the template
@@ -235,7 +238,11 @@ public final class AppTemplateService
     private static HtmlTemplate loadTemplate( String strPath, String strTemplate, Locale locale, Object model )
     {
         HtmlTemplate template;
-        template = getFreeMarkerTemplateService(  ).loadTemplate( strPath, strTemplate, locale, model );
+        if ( getJadeTemplateService(  ).canHandle( strTemplate ) ) {
+            template = getJadeTemplateService(  ).loadTemplate( strPath, strTemplate, locale, model );
+        } else {
+            template = getFreeMarkerTemplateService(  ).loadTemplate( strPath, strTemplate, locale, model );
+        }
 
         if ( locale != null )
         {
@@ -290,4 +297,16 @@ public final class AppTemplateService
 
         return _freeMarkerTemplateService;
     }
+
+    private static IJadeTemplateService getJadeTemplateService(  )
+    {
+       if ( _jadeTemplateService == null )
+       {
+           _jadeTemplateService = JadeTemplateService.getInstance(  );
+           _jadeTemplateService.init( _strTemplateDefaultPath );
+       }
+
+       return _jadeTemplateService;
+    }
+
 }

--- a/src/java/fr/paris/lutece/portal/service/template/JadeTemplateService.java
+++ b/src/java/fr/paris/lutece/portal/service/template/JadeTemplateService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.template;
+
+import fr.paris.lutece.portal.service.util.AppPathService;
+
+/**
+ * Template service based on the jade template engine
+ * @see http://jade-lang.com/
+ */
+public class JadeTemplateService extends AbstractJadeTemplateService
+{
+
+    /**
+     * singleton instance
+     */
+    private static final IJadeTemplateService _singleton = new JadeTemplateService(  );
+
+    /**
+     * Get the singleton instance
+     * @return the singleton instance
+     */
+    public static IJadeTemplateService getInstance(  )
+    {
+        return _singleton;
+    }
+
+    @Override
+    protected String getAbsolutePathFromRelativePath( String strPath )
+    {
+        return AppPathService.getAbsolutePathFromRelativePath( strPath );
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/portal/service/template/AppTemplateServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/template/AppTemplateServiceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.template;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import fr.paris.lutece.test.LuteceTestCase;
+import fr.paris.lutece.util.html.HtmlTemplate;
+
+public class AppTemplateServiceTest extends LuteceTestCase
+{
+
+    public void testJadeTemplate(  )
+    {
+        Map<String, Object> model = new HashMap<String, Object>(  );
+        model.put( "variable", "value" );
+        HtmlTemplate template = AppTemplateService.getTemplate( "../../../test-classes/AppTemplateServiceTest.jade", Locale.FRANCE, model );
+        assertEquals( "<div class=\"test\"><p>variable=value</p></div>", template.getHtml(  ) );
+    }
+
+    public void testJadeInFreemarkerTemplate(  ) throws IOException
+    {
+        File templateFile = new File( getResourcesDir(  ), "../test-classes/AppTemplateServiceTest.html" );
+        File dest = new File( getResourcesDir(  ), "WEB-INF/templates/AppTemplateServiceTest.html" );
+        try
+        {
+            Files.copy( templateFile.toPath(  ), dest.toPath(  ), StandardCopyOption.REPLACE_EXISTING );
+            Map<String, Object> model = new HashMap<String, Object>(  );
+            model.put( "variable", "value" );
+            HtmlTemplate template = AppTemplateService.getTemplate( "AppTemplateServiceTest.html", Locale.FRANCE, model );
+            assertEquals( "value\n<div class=\"test\"><p>variable=value</p></div>", template.getHtml(  ) );
+        } finally
+        {
+            dest.delete(  );
+        }
+    }
+
+}

--- a/src/test/resources/AppTemplateServiceTest.html
+++ b/src/test/resources/AppTemplateServiceTest.html
@@ -1,0 +1,5 @@
+${variable}
+<@jade>
+.test
+	p variable=${r"#{variable}"}
+</@jade>

--- a/src/test/resources/AppTemplateServiceTest.jade
+++ b/src/test/resources/AppTemplateServiceTest.jade
@@ -1,0 +1,2 @@
+.test
+	p variable=#{variable}


### PR DESCRIPTION
Requires the library-jade library.

This library is available at https://github.com/rzara/lutece-tech-library-jade

*.jade template files are routed to the JadeTemplateService.
Jade templates can be embedded in freemarker templates by using the
@jade directive :

	<@jade>
		p.jade
		span variable's value is ${r"#{variable}"}
	</@jade>

The body of the directive is first evaluated by freemarker before being
processed by jade.