### PR TITLE
LUTECE-1938 : add the role name to role deletion messages

### DIFF
--- a/src/java/fr/paris/lutece/portal/resources/role_messages.properties
+++ b/src/java/fr/paris/lutece/portal/resources/role_messages.properties
@@ -3,13 +3,13 @@
 
 # admin features
 adminFeature.roles_management.name=Lutece Role management
-adminFeature.roles_management.description=Accespages role management
+adminFeature.roles_management.description=Page access role management
 
 # messages
 message.roleexist=This role already exist !
-message.roleformat=Role name cannot contain specials charaters (spaces, accents, quotes, ...) !
-message.confirmRemoveRole=Do you really want to remove this role ?
-message.cannotRemoveRole=You can''t delete this role : {0}
+message.roleformat=Role name cannot contain specials characters (spaces, accents, quotes, ...) !
+message.confirmRemoveRole=Do you really want to remove the role {0} ?
+message.cannotRemoveRole=You can''t delete the role {0} : {1}
 
 ###################################################################################
 # Templates

--- a/src/java/fr/paris/lutece/portal/resources/role_messages_fr.properties
+++ b/src/java/fr/paris/lutece/portal/resources/role_messages_fr.properties
@@ -8,8 +8,8 @@ adminFeature.roles_management.description=Gestion des r\u00f4les d'acc\u00e8s au
 # messages
 message.roleexist=Ce r\u00f4le existe d\u00e9j\u00e0 !
 message.roleformat=Le nom du r\u00f4le ne peut pas contenir de caract\u00e8res sp\u00e9ciaux (espaces, accents, guillemets, ...) !
-message.confirmRemoveRole=Voulez vous r\u00e9ellement supprimer ce r\u00f4le ?
-message.cannotRemoveRole=Vous ne pouvez pas supprimer ce r\u00f4le : {0}
+message.confirmRemoveRole=Voulez vous r\u00e9ellement supprimer le r\u00f4le {0} ?
+message.cannotRemoveRole=Vous ne pouvez pas supprimer le r\u00f4le {0} : {1}
 
 ###################################################################################
 # Templates

--- a/src/java/fr/paris/lutece/portal/web/role/RoleJspBean.java
+++ b/src/java/fr/paris/lutece/portal/web/role/RoleJspBean.java
@@ -53,6 +53,8 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang.StringUtils;
+
 
 /**
  * JspBean for Role management
@@ -248,9 +250,21 @@ public class RoleJspBean extends AdminFeaturesPageJspBean
      */
     public String getRemovePageRole( HttpServletRequest request )
     {
+        String strPageRole = request.getParameter( PARAMETER_PAGE_ROLE );
+        if ( StringUtils.isBlank( strPageRole ) )
+        {
+            return AdminMessageService.getMessageUrl( request, Messages.MESSAGE_INVALID_ENTRY,
+                    new Object[] { PARAMETER_PAGE_ROLE }, AdminMessage.TYPE_STOP );
+        }
+        Role role = RoleHome.findByPrimaryKey( strPageRole );
+        if ( role == null || !strPageRole.equals( role.getRole( ) ) )
+        {
+            return AdminMessageService.getMessageUrl( request, Messages.MESSAGE_INVALID_ENTRY,
+                    new Object[] { strPageRole }, AdminMessage.TYPE_STOP );
+        }
         UrlItem url = new UrlItem( PATH_JSP + JSP_REMOVE_ROLE + "?role=" + request.getParameter( PARAMETER_PAGE_ROLE ) );
 
-        return AdminMessageService.getMessageUrl( request, MESSAGE_CONFIRM_REMOVE, url.getUrl(  ),
+        return AdminMessageService.getMessageUrl( request, MESSAGE_CONFIRM_REMOVE, new Object[] { strPageRole }, url.getUrl(  ),
             AdminMessage.TYPE_CONFIRMATION );
     }
 
@@ -267,7 +281,7 @@ public class RoleJspBean extends AdminFeaturesPageJspBean
         if ( !RoleRemovalListenerService.getService(  ).checkForRemoval( strPageRole, listErrors, getLocale(  ) ) )
         {
             String strCause = AdminMessageService.getFormattedList( listErrors, getLocale(  ) );
-            Object[] args = { strCause };
+            Object[] args = { strPageRole, strCause };
 
             return AdminMessageService.getMessageUrl( request, MESSAGE_CANNOT_REMOVE_ROLE, args, AdminMessage.TYPE_STOP );
         }

--- a/src/test/java/fr/paris/lutece/portal/web/role/RoleJspBeanTest.java
+++ b/src/test/java/fr/paris/lutece/portal/web/role/RoleJspBeanTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2015, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.web.role;
+
+import java.security.SecureRandom;
+import java.util.Locale;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import fr.paris.lutece.portal.business.role.Role;
+import fr.paris.lutece.portal.business.role.RoleHome;
+import fr.paris.lutece.portal.service.i18n.I18nService;
+import fr.paris.lutece.portal.service.message.AdminMessage;
+import fr.paris.lutece.portal.service.message.AdminMessageService;
+import fr.paris.lutece.portal.service.workgroup.AdminWorkgroupService;
+import fr.paris.lutece.test.LuteceTestCase;
+import fr.paris.lutece.util.ReferenceItem;
+import fr.paris.lutece.util.ReferenceList;
+
+public class RoleJspBeanTest extends LuteceTestCase
+{
+    private static final String PARAMETER_PAGE_ROLE = "role";
+
+    public void testGetRemovePageRole( )
+    {
+        RoleJspBean bean = new RoleJspBean( );
+        MockHttpServletRequest request = new MockHttpServletRequest( );
+        // no args
+        bean.getRemovePageRole( request );
+        AdminMessage message = AdminMessageService.getMessage( request );
+        assertNotNull( message );
+        ReferenceList listLanguages = I18nService.getAdminLocales( Locale.FRANCE );
+        for ( ReferenceItem lang : listLanguages )
+        {
+            assertTrue( message.getText( new Locale( lang.getCode( ) ) ).contains( PARAMETER_PAGE_ROLE ) );
+        }
+        // invalid arg
+        String randomRoleName = "role" + new SecureRandom(  ).nextLong(  );
+        request = new MockHttpServletRequest( );
+        request.addParameter( PARAMETER_PAGE_ROLE, randomRoleName );
+        bean.getRemovePageRole( request );
+        message = AdminMessageService.getMessage( request );
+        assertNotNull( message );
+        for ( ReferenceItem lang : listLanguages )
+        {
+            assertTrue( message.getText( new Locale( lang.getCode( ) ) ).contains( randomRoleName ) );
+        }
+        // valid arg
+        Role role = new Role( );
+        role.setRole( randomRoleName );
+        role.setRoleDescription( randomRoleName );
+        role.setWorkgroup( AdminWorkgroupService.ALL_GROUPS );
+        RoleHome.create( role );
+        try
+        {
+            request = new MockHttpServletRequest( );
+            request.addParameter( PARAMETER_PAGE_ROLE, randomRoleName );
+            bean.getRemovePageRole( request );
+            message = AdminMessageService.getMessage( request );
+            assertNotNull( message );
+            for ( ReferenceItem lang : listLanguages )
+            {
+                assertTrue( message.getText( new Locale( lang.getCode( ) ) ).contains( randomRoleName ) );
+            }
+        } finally
+        {
+            RoleHome.remove( randomRoleName );
+        }
+    }
+}


### PR DESCRIPTION
Also add a message when request arguments are incorrect, fix a typo and
add a test verifiyng that the role name is present in the messages.