### PR TITLE
LUTECE-1967 : Change the default path in config.properties

### DIFF
--- a/webapp/WEB-INF/conf/config.properties
+++ b/webapp/WEB-INF/conf/config.properties
@@ -82,10 +82,10 @@ indexer.param.total=false
 
 ################################################################################
 # Properties files
-file.lutece.properties=C:/Java/projets/lutece-svn/webapp/WEB-INF/conf/lutece.properties
-file.webmaster.properties=C:/Java/projets/lutece-svn/webapp/WEB-INF/conf/webmaster.properties
-file.jtidy.properties=C:/Java/projets/lutece-svn/webapp/WEB-INF/conf/jtidy.properties
-file.dir.plugins=C:/Java/projets/lutece-svn/webapp/WEB-INF/conf/plugins
+file.lutece.properties=target/lutece/WEB-INF/conf/lutece.properties
+file.webmaster.properties=target/lutece/WEB-INF/conf/webmaster.properties
+file.jtidy.properties=target/lutece/WEB-INF/conf/jtidy.properties
+file.dir.plugins=target/lutece/WEB-INF/conf/plugins
 
 ################################################################################
 # Error page management
@@ -110,8 +110,8 @@ lutece.debug.tracePortletXml=false
 
 ################################################################################
 # Site validation
-file.validation.flag=C:/Java/projets/lutece-svn/webapp/WEB-INF/exploit/validation.flag
-file.amin.validation.flag=C:/Java/projets/lutece-svn/webapp/WEB-INF/exploit/admin_validation.flag
+file.validation.flag=target/lutece/WEB-INF/exploit/validation.flag
+file.amin.validation.flag=target/lutece/WEB-INF/exploit/admin_validation.flag
 
 
 ################################################################################
@@ -151,7 +151,7 @@ log4j.logger.org.apache.tika=ERROR, Indexer
 
 # File "error.log"
 log4j.appender.Error=org.apache.log4j.RollingFileAppender
-log4j.appender.Error.File=C:/Java/projets/lutece-svn/webapp/WEB-INF/logs/error.log
+log4j.appender.Error.File=target/lutece/WEB-INF/logs/error.log
 log4j.appender.Error.Append=true
 log4j.appender.Error.layout=org.apache.log4j.PatternLayout
 log4j.appender.Error.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} %-5p [%t] %c{2} - %m%n
@@ -160,7 +160,7 @@ log4j.appender.Error.MaxBackupIndex=5
 
 # File "application.log"
 log4j.appender.Application=org.apache.log4j.RollingFileAppender
-log4j.appender.Application.File=C:/Java/projets/lutece-svn/webapp/WEB-INF/logs/application.log
+log4j.appender.Application.File=target/lutece/WEB-INF/logs/application.log
 log4j.appender.Application.Append=true
 log4j.appender.Application.layout=org.apache.log4j.PatternLayout
 log4j.appender.Application.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} %-5p [%t] %c{2} - %m%n
@@ -169,7 +169,7 @@ log4j.appender.Application.MaxBackupIndex=5
 
 # File "pool.log"
 log4j.appender.Pool=org.apache.log4j.RollingFileAppender
-log4j.appender.Pool.File=C:/Java/projets/lutece-svn/webapp/WEB-INF/logs/pool.log
+log4j.appender.Pool.File=target/lutece/WEB-INF/logs/pool.log
 log4j.appender.Pool.Append=true
 log4j.appender.Pool.layout=org.apache.log4j.PatternLayout
 log4j.appender.Pool.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} %-5p [%t] %c{2} - %m%n
@@ -178,7 +178,7 @@ log4j.appender.Pool.MaxBackupIndex=5
 
 # File "mail.log"
 log4j.appender.Mail=org.apache.log4j.RollingFileAppender
-log4j.appender.Mail.File=C:/Java/projets/lutece-svn/webapp/WEB-INF/logs/mail.log
+log4j.appender.Mail.File=target/lutece/WEB-INF/logs/mail.log
 log4j.appender.Mail.Append=true
 log4j.appender.Mail.layout=org.apache.log4j.PatternLayout
 log4j.appender.Mail.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} %-5p [%t] %c{2} - %m%n
@@ -187,7 +187,7 @@ log4j.appender.Mail.MaxBackupIndex=5
 
 # File "PDF.log"
 log4j.appender.PDF=org.apache.log4j.RollingFileAppender
-log4j.appender.PDF.File=C:/Java/projets/lutece-svn/webapp/WEB-INF/logs/PDF.log
+log4j.appender.PDF.File=target/lutece/WEB-INF/logs/PDF.log
 log4j.appender.PDF.Append=true
 log4j.appender.PDF.layout=org.apache.log4j.PatternLayout
 log4j.appender.PDF.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} %-5p [%t] %c{2} - %m%n
@@ -196,7 +196,7 @@ log4j.appender.PDF.MaxBackupIndex=5
 
 # File "security.log"
 log4j.appender.Security=org.apache.log4j.RollingFileAppender
-log4j.appender.Security.File=C:/Java/projets/lutece-svn/webapp/WEB-INF/logs/security.log
+log4j.appender.Security.File=target/lutece/WEB-INF/logs/security.log
 log4j.appender.Security.Append=true
 log4j.appender.Security.layout=org.apache.log4j.PatternLayout
 log4j.appender.Security.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} %-5p [%t] %c{2} - %m%n
@@ -205,7 +205,7 @@ log4j.appender.Security.MaxBackupIndex=5
 
 # File "jpa.log"
 log4j.appender.JPA=org.apache.log4j.RollingFileAppender
-log4j.appender.JPA.File=C:/Java/projets/lutece-svn/webapp/WEB-INF/logs/jpa.log
+log4j.appender.JPA.File=target/lutece/WEB-INF/logs/jpa.log
 log4j.appender.JPA.Append=true
 log4j.appender.JPA.layout=org.apache.log4j.PatternLayout
 log4j.appender.JPA.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} %-5p [%t] %c{2} - %m%n
@@ -214,7 +214,7 @@ log4j.appender.JPA.MaxBackupIndex=5
 
 # File "indexer.log"
 log4j.appender.Indexer=org.apache.log4j.RollingFileAppender
-log4j.appender.Indexer.File=C:/Java/projets/lutece-svn/webapp/WEB-INF/logs/indexer.log
+log4j.appender.Indexer.File=target/lutece/WEB-INF/logs/indexer.log
 log4j.appender.Indexer.Append=true
 log4j.appender.Indexer.layout=org.apache.log4j.PatternLayout
 log4j.appender.Indexer.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} %-5p [%t] %c{2} - %m%n


### PR DESCRIPTION
Replace the default paths in config.properties by ones that
match any dev environnement : when tests are run from maven, the
working directory is the project base directory.
The paths will be updated with absolute ones when running the app, but
the config.properties file is already read at this stage.
The second run will read the customized paths.

This makes HtmlCleanerServiceTest#testClean pass because the
expected jtidy.properties is read.