### PR TITLE
LUTECE-1968 : Ensure that there is no authenticationService if authentication is disabled.

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/security/SecurityService.java
+++ b/src/java/fr/paris/lutece/portal/service/security/SecurityService.java
@@ -96,6 +96,10 @@ public final class SecurityService
             {
                 _bEnable = true;
             }
+        } else
+        {
+            // in case authentication is disabled after having been enabled
+            _authenticationService = null;
         }
     }
 


### PR DESCRIPTION
This allows to get the same behavior is authentication is enabled then disabled
as if it is disabled from the start.

This fixes SecurityServiceTest#testLoginUser when run as part of the suite.