### PR TITLE
LUTECE-1969 : Check that initializing SpringContextService twice fails

### DIFF
--- a/src/test/java/fr/paris/lutece/portal/service/spring/SpringContextServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/spring/SpringContextServiceTest.java
@@ -59,14 +59,15 @@ public class SpringContextServiceTest extends LuteceTestCase
         assertTrue( LuteceDefaultAdminAuthentication.class.isInstance( result ) );
     }
 
-    public void testInit(  ) throws LuteceInitException
+    public void testInit(  )
     {
         System.out.println( "init" );
-        SpringContextService.init( null );
-
-        for ( String name : SpringContextService.getContext(  ).getBeanDefinitionNames(  ) )
+        try
         {
-            System.out.println( name );
+            SpringContextService.init( null );
+            fail( "cannot init SpringContextService twice" );
+        } catch ( LuteceInitException e )
+        {
         }
     }
 


### PR DESCRIPTION
Maybe it would be better to let that work, but this is a lot more work,
and the use case needs to be determined.