### PR TITLE
LUTECE-2025 : Use PBKDF2WithHmacSHA512 to store BO passwords

### DIFF
--- a/src/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactory.java
+++ b/src/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactory.java
@@ -61,7 +61,7 @@ final class PasswordFactory implements IPasswordFactory
 {
     // storage types
     private static final String PBKDF2WITHHMACSHA1_STORAGE_TYPE = "PBKDF2";
-    private static final String PBKDF2WITHHMACSHA512_STORAGE_STYPE = "PBKDF2WITHHMACSHA512";
+    private static final String PBKDF2WITHHMACSHA512_STORAGE_TYPE = "PBKDF2WITHHMACSHA512";
     private static final String PLAINTEXT_STORAGE_TYPE = "PLAINTEXT";
     private static final String DUMMY_STORAGE_TYPE = "\0DUMMY\0";
     private static final String DUMMY_STORED_PASSWORD = DUMMY_STORAGE_TYPE + ":\0";
@@ -82,7 +82,7 @@ final class PasswordFactory implements IPasswordFactory
                 return new PlaintextPassword( password );
             case PBKDF2WITHHMACSHA1_STORAGE_TYPE:
                 return new PBKDF2WithHmacSHA1Password( password );
-            case PBKDF2WITHHMACSHA512_STORAGE_STYPE:
+            case PBKDF2WITHHMACSHA512_STORAGE_TYPE:
                 return new PBKDF2WithHmacSHA512Password( password );
             case DUMMY_STORAGE_TYPE:
                 return new DummyPassword( );
@@ -299,7 +299,7 @@ final class PasswordFactory implements IPasswordFactory
     }
 
     /**
-     * A Password stored using PBKDF2WithHmacSHA256
+     * A Password stored using PBKDF2WithHmacSHA512
      */
     private static class PBKDF2WithHmacSHA512Password extends PBKDF2Password
     {
@@ -343,7 +343,7 @@ final class PasswordFactory implements IPasswordFactory
         @Override
         protected String getStorageType( )
         {
-            return PBKDF2WITHHMACSHA512_STORAGE_STYPE;
+            return PBKDF2WITHHMACSHA512_STORAGE_TYPE;
         }
 
     }

--- a/src/test/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactoryTest.java
+++ b/src/test/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactoryTest.java
@@ -132,12 +132,32 @@ public class PasswordFactoryTest extends LuteceTestCase
         }
     }
 
-    public void testGetPasswordPBKDF2( )
+    public void testGetPasswordPBKDF2WithHmacSHA1( )
     {
         PasswordFactory passwordFactory = new PasswordFactory( );
-        String storedPassword = "PBKDF2:40000:c2d05d21e68313aaf55cf16751c53dd9:" + "da09ad1888f548ddf5f2cb0a0b9904aaf547e4b6722d4e04ac75dab73b87d379"
-                + "be5b312a50b15c2dcdd9b745b616492c85a8e8e4a8b75e8abf1b99507680e30b" + "efb6bfdc9b3e0493dcccc43be6dcc24be3015bf966a66797047d75b938784921"
+        String storedPassword = "PBKDF2:40000:c2d05d21e68313aaf55cf16751c53dd9:da09ad1888f548ddf5f2cb0a0b9904aaf547e4b6722d4e04ac75dab73b87d379"
+                + "be5b312a50b15c2dcdd9b745b616492c85a8e8e4a8b75e8abf1b99507680e30befb6bfdc9b3e0493dcccc43be6dcc24be3015bf966a66797047d75b938784921"
                 + "710b0de6e3643cc8088ec7315e1e03c91250b5c4a65de8adb0a7351a1564bbb7";
+        IPassword password = passwordFactory.getPassword( storedPassword );
+        assertEquals( true, password.check( "PASSWORD" ) );
+        assertEquals( false, password.check( "BAR" ) );
+        assertTrue( password.isLegacy( ) );
+        try
+        {
+            password.getStorableRepresentation( );
+            fail( );
+        }
+        catch( UnsupportedOperationException e )
+        {
+        }
+    }
+
+    public void testGetPasswordPBKDF2WithHmacSHA512( )
+    {
+        PasswordFactory passwordFactory = new PasswordFactory( );
+        String storedPassword = "PBKDF2WITHHMACSHA512:40000:90be05c0b062cdc94fd6124a88f95523:4e574b19813e5e5af7ae936a1798b0c12f28b79bb761f32f94270b31"
+                + "731f44bca37513855af9c08f7abf09e65bc46f9f1b25d39b31a657b5649c7bc8020e1486ae854c5aefdb73a74e4ceb0acd96abee24ca68cf8c0403b7602952f0a0"
+                + "bf8662a4c83c4c28ecb0c282d2afe49e71870e260c07f419c9ddd3c63115694864b1e5";
         IPassword password = passwordFactory.getPassword( storedPassword );
         assertEquals( true, password.check( "PASSWORD" ) );
         assertEquals( false, password.check( "BAR" ) );


### PR DESCRIPTION
This algorithm is supported since Java 1.8, and is more resistant to
attacks than PBKDF2WithHmacSHA1.
Downgrade PBKDF2WithHmacSHA1 to legacy status, but keep support for reading them.