### PR TITLE
LUTECE-2040 : enable tracing of Lutece daemons by Nudge

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/daemon/DaemonEntry.java
+++ b/src/java/fr/paris/lutece/portal/service/daemon/DaemonEntry.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.portal.service.daemon;
 
+import fr.paris.lutece.portal.service.spring.SpringContextService;
 import fr.paris.lutece.util.date.DateUtil;
 
 import java.util.Date;
@@ -52,7 +53,7 @@ public final class DaemonEntry
     private boolean _bOnStartup;
     private boolean _bIsRunning;
     private Daemon _daemon;
-    private DaemonThread _thread;
+    private final DaemonThread _thread;
     private String _strPluginName;
 
     // Variables declarations
@@ -62,7 +63,8 @@ public final class DaemonEntry
      */
     public DaemonEntry( )
     {
-        _thread = new DaemonThread( this );
+        _thread = SpringContextService.getBean( DaemonThread.DEAMON_THREAD_BEAN_NAME );
+        _thread.setDaemonEntry( this );
     }
 
     /**

--- a/src/java/fr/paris/lutece/portal/service/daemon/DaemonThread.java
+++ b/src/java/fr/paris/lutece/portal/service/daemon/DaemonThread.java
@@ -41,20 +41,30 @@ import java.util.Date;
 /**
  * This class performs methods to manage threads of execution for a given daemon instance
  */
-public final class DaemonThread implements Runnable
+public class DaemonThread implements Runnable
 {
+    static final String DEAMON_THREAD_BEAN_NAME = "daemonThread";
+
     private DaemonEntry _entry;
     private String _strDaemonName;
 
     /**
-     * Constructor Creates the thread of execution from informations contained in DaemonEntry structure
-     * 
+     * Sets the daemon entry
      * @param entry
      *            The entry
      */
-    public DaemonThread( DaemonEntry entry )
+    public void setDaemonEntry( DaemonEntry entry )
     {
         _entry = entry;
+    }
+
+    /**
+     * Get the daemon name
+     * @return the daemon name
+     */
+    public String getDaemonName( )
+    {
+        return _strDaemonName;
     }
 
     /**

--- a/webapp/WEB-INF/conf/core_context.xml
+++ b/webapp/WEB-INF/conf/core_context.xml
@@ -203,4 +203,5 @@
     
     <bean id="core.xpage.search" class="fr.paris.lutece.portal.web.search.SearchApp" scope="session" />
 
+    <bean id="daemonThread" class="fr.paris.lutece.portal.service.daemon.DaemonThread" scope="prototype" />
 </beans>


### PR DESCRIPTION
Daemons are reported by their names in transactions, and are grouped as "Lutece Daemon"
in Nudge's map view.
No configuration of the probe is necessary.