### PR TITLE
Improve compatibility with MySQL server >= 5.5.3

### DIFF
--- a/src/sql/init_db/init_session_mysql.sql
+++ b/src/sql/init_db/init_session_mysql.sql
@@ -1,1 +1,1 @@
-SET storage_engine=MyISAM;
+SET default_storage_engine = MyISAM;


### PR DESCRIPTION
`storage_engine` variable is deprecated since v5.5.3 of MySQL server. 
Now we should use `default_storage_engine` variable.
Please refer to [the documentation](https://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html#sysvar_default_storage_engine)