### PR TITLE
LUTECE-2047 : Use a token system to reset backoffice users password

### DIFF
--- a/src/java/fr/paris/lutece/portal/resources/admin_messages.properties
+++ b/src/java/fr/paris/lutece/portal/resources/admin_messages.properties
@@ -41,7 +41,7 @@ admin_forgot_login.text=Please enter your e-mail to receive your access code.
 
 admin_forgot_password.email.subject=Password reinitialization
 admin_forgot_password.email.title=Password reinitialization
-admin_forgot_password.email.textResetPassword=A password reset has been requested for your account. If you did not fill this request, you can ignore this message. Otherwise, the following link will let you define a new password. This link is valid until {0,date,dd MMMM hh:mm}.
+admin_forgot_password.email.textResetPassword=A password reset has been requested for your account. If you did not fill this request, you can ignore this message. Otherwise, the following link will let you define a new password. This link is valid until {0,date,dd MMMM HH:mm}.
 admin_forgot_password.email.textResetPasswordTokenLockedToSession=You must open this link in the same browser session that you used to have this message sent.
 
 admin_forgot_login.email.subject=Access code recovery

--- a/src/java/fr/paris/lutece/portal/resources/admin_messages.properties
+++ b/src/java/fr/paris/lutece/portal/resources/admin_messages.properties
@@ -41,15 +41,17 @@ admin_forgot_login.text=Please enter your e-mail to receive your access code.
 
 admin_forgot_password.email.subject=Password reinitialization
 admin_forgot_password.email.title=Password reinitialization
-admin_forgot_password.email.textResetPassword=Your password has been reinitialized.
-admin_forgot_password.email.textNewPassword=Your password has been changed to
-admin_forgot_password.email.textChangePassword=You can change your password here
+admin_forgot_password.email.textResetPassword=A password reset has been requested for your account. If you did not fill this request, you can ignore this message. Otherwise, the following link will let you define a new password. This link is valid until {0,date,dd MMMM hh:mm}.
+admin_forgot_password.email.textResetPasswordTokenLockedToSession=You must open this link in the same browser session that you used to have this message sent.
 
 admin_forgot_login.email.subject=Access code recovery
 admin_forgot_login.email.title=Access code recovery
 admin_forgot_login.email.textYourLogin=Your access code is
 admin_forgot_login.email.textLogin=You can log in by following the link
 
+# Template admin_reset_password
+admin_reset_password.text=Please enter your new password
+admin_reset_password.buttonSubmit=Submit
 
 # Template admin_form_contact
 admin_form_contact.title=Lutece - Administration module - Contact an administrator
@@ -65,10 +67,13 @@ message.buttonValidate=OK
 message.buttonCancel=Cancel
 message.admin_form_contact.sendingError=The user login or mail adress are invalid.<br />To send an account reinitialization request to administrators, please complete this form :
 message.admin_form_contact.sendingSuccess=The message has been sended to administrator(s).
-message.admin_forgot_password.sendingSuccess=The password have been reinitialized, a mail has been sended to user.
+message.admin_forgot_password.sendingSuccess=An email has been sent to the user for this access code so that they can reinit their password.
 message.admin_forgot_login.sendingSuccess=Your access code has successfully been sended by e-mail.
 message.admin_forgot_login.wrongEmailFormat=The format of the email is not correct.
 message.wrongCaptcha=The captcha is not valid
+message.invalid.reset.token=The password reset code is invalid.<br>The password may have already been changed, or the link used is incorrect.
+message.expired.reset.token=The password reset code has expired.<br>Please renew your request.
+message.reset.password.success=The password reset was successful.
 
 # Extender messages
 resource.extend=Extenders

--- a/src/java/fr/paris/lutece/portal/resources/admin_messages_fr.properties
+++ b/src/java/fr/paris/lutece/portal/resources/admin_messages_fr.properties
@@ -42,14 +42,17 @@ admin_forgot_login.text=Veuillez saisir votre e-mail pour recevoir votre code d'
 
 admin_forgot_password.email.subject=R\u00e9initialisation du mot de passe
 admin_forgot_password.email.title=R\u00e9initialisation du mot de passe
-admin_forgot_password.email.textResetPassword=Votre mot de passe a \u00e9t\u00e9 r\u00e9initialis\u00e9.
-admin_forgot_password.email.textNewPassword=Voici votre nouveau mot de passe
-admin_forgot_password.email.textChangePassword=Vous pouvez changer votre mot de passe ici
+admin_forgot_password.email.textResetPassword=Une demande de réinitialisation de mot de passe a été effectuée pour votre compte. Si vous n''êtes pas à l''origine de cette demande, vous pouvez ignorer ce message. Sinon, le lien ci-dessous vous permettra de définir un nouveau mot de passe. Ce lien est valide jusqu''au {0,date,dd MMMM hh:mm}.
+admin_forgot_password.email.textResetPasswordTokenLockedToSession=Vous devez ouvrir ce lien dans la même session navigateur que vous avez utilisée pour provoquer l'envoi de ce message.
 
 admin_forgot_login.email.subject=R\u00e9cup\u00e9ration du code d'acc\u00e8s
 admin_forgot_login.email.title=R\u00e9cup\u00e9ration du code d'acc\u00e8s
 admin_forgot_login.email.textYourLogin=Votre code d'acc\u00e8s est
 admin_forgot_login.email.textLogin=Vous pouvez vous connecter au site en suivant le lien suivant
+
+# Template admin_reset_password
+admin_reset_password.text=Veuillez saisir votre nouveau mot de passe
+admin_reset_password.buttonSubmit=Valider
 
 # Template admin_form_contact
 admin_form_contact.title=Lut\u00e8ce - Module d'administration - Contacter un administrateur
@@ -65,10 +68,13 @@ message.buttonValidate=OK
 message.buttonCancel=Annuler
 message.admin_form_contact.sendingError=Le login utilisateur n'a pas \u00e9t\u00e9 trouv\u00e9 ou l'adresse e-mail est incorrecte.<br />Pour envoyer une demande de r\u00e9initialisation de compte aux administrateurs, remplissez le formulaire suivant :
 message.admin_form_contact.sendingSuccess=Le message a \u00e9t\u00e9 envoy\u00e9 a(ux) administrateur(s).
-message.admin_forgot_password.sendingSuccess=Le mot de passe a \u00e9t\u00e9 r\u00e9initialis\u00e9, un e-mail \u00e0 \u00e9t\u00e9 envoy\u00e9 \u00e0 l'utilisateur correspondant au login.
+message.admin_forgot_password.sendingSuccess=Un e-mail \u00e0 \u00e9t\u00e9 envoy\u00e9 \u00e0 l'utilisateur correspondant au login afin qu'il puisse réinitialiser son mot de passe.
 message.admin_forgot_login.sendingSuccess=Votre code d'acc\u00e8s a bien \u00e9t\u00e9 envoy\u00e9 par e-mail.
 message.admin_forgot_login.wrongEmailFormat=Le format de l'email n'est pas valide.
 message.wrongCaptcha=Le captcha n'est pas correct
+message.invalid.reset.token=Le code de réinitialisation du mot de passe est invalide.<br>Le mot de passe a peut-être déjà été changé, ou le lien utilisé est incorrect.
+message.expired.reset.token=Le code de réinitialisation du mot de passe a expiré.<br>Merci de renouveller votre demande.
+message.reset.password.success=Le mot de passe a bien été réinitialisé.
 
 # Extender messages
 resource.extend=Extensions

--- a/src/java/fr/paris/lutece/portal/resources/admin_messages_fr.properties
+++ b/src/java/fr/paris/lutece/portal/resources/admin_messages_fr.properties
@@ -42,7 +42,7 @@ admin_forgot_login.text=Veuillez saisir votre e-mail pour recevoir votre code d'
 
 admin_forgot_password.email.subject=R\u00e9initialisation du mot de passe
 admin_forgot_password.email.title=R\u00e9initialisation du mot de passe
-admin_forgot_password.email.textResetPassword=Une demande de réinitialisation de mot de passe a été effectuée pour votre compte. Si vous n''êtes pas à l''origine de cette demande, vous pouvez ignorer ce message. Sinon, le lien ci-dessous vous permettra de définir un nouveau mot de passe. Ce lien est valide jusqu''au {0,date,dd MMMM hh:mm}.
+admin_forgot_password.email.textResetPassword=Une demande de réinitialisation de mot de passe a été effectuée pour votre compte. Si vous n''êtes pas à l''origine de cette demande, vous pouvez ignorer ce message. Sinon, le lien ci-dessous vous permettra de définir un nouveau mot de passe. Ce lien est valide jusqu''au {0,date,dd MMMM HH:mm}.
 admin_forgot_password.email.textResetPasswordTokenLockedToSession=Vous devez ouvrir ce lien dans la même session navigateur que vous avez utilisée pour provoquer l'envoi de ce message.
 
 admin_forgot_login.email.subject=R\u00e9cup\u00e9ration du code d'acc\u00e8s

--- a/src/java/fr/paris/lutece/portal/resources/users_messages.properties
+++ b/src/java/fr/paris/lutece/portal/resources/users_messages.properties
@@ -300,6 +300,8 @@ manage_advanced_parameters.labelAccesFailuresMax=Maximum number of login attempt
 manage_advanced_parameters.labelAccesFailuresInterval=Login attempt interval (in minutes)
 manage_advanced_parameters.labelBannedDomainNames=List of banned email domain names (semicolon separated)
 manage_advanced_parameters.labelNotifyUserPasswordExpired=Notify users when their passwords expired
+manage_advanced_parameters.labelResetTokenValidity=Password reset token life time (in minutes)
+manage_advanced_parameters.labelLockResetTokenToSession=Lock the password reset token to the browser session
 
 
 # Template create_attribute

--- a/src/java/fr/paris/lutece/portal/resources/users_messages_fr.properties
+++ b/src/java/fr/paris/lutece/portal/resources/users_messages_fr.properties
@@ -298,6 +298,8 @@ manage_advanced_parameters.labelAccesFailuresMax=Nombre maximum de tentatives de
 manage_advanced_parameters.labelAccesFailuresInterval=Dur\u00e9e du blocage des connexions (en minutes)
 manage_advanced_parameters.labelBannedDomainNames=Liste des noms de domaine interdits pour les email (separ\u00e9s par des points virgules)
 manage_advanced_parameters.labelNotifyUserPasswordExpired=Notifier les utilisateurs lorsque leur mot de passe expire
+manage_advanced_parameters.labelResetTokenValidity=Durée de vie du jeton de réinitialisation de mot de passe (en minutes)
+manage_advanced_parameters.labelLockResetTokenToSession=Lier le jeton de réinitialisation de mot de passe à la session du navigateur
 
 
 # Template create_attribute

--- a/src/java/fr/paris/lutece/portal/service/admin/AdminUserService.java
+++ b/src/java/fr/paris/lutece/portal/service/admin/AdminUserService.java
@@ -127,6 +127,8 @@ public final class AdminUserService
     public static final String DSKEY_DEFAULT_USER_NOTIFICATION = "core.advanced_parameters.default_user_notification";
     public static final String DSKEY_DEFAULT_USER_LEVEL = "core.advanced_parameters.default_user_level";
     public static final String DSKEY_USE_ADVANCED_SECURITY_PARAMETERS = "core.advanced_parameters.use_advanced_security_parameters";
+    public static final String DSKEY_RESET_TOKEN_VALIDITY = "core.advanced_parameters.reset_token_validity";
+    public static final String DSKEY_LOCK_RESET_TOKEN_TO_SESSION = "core.advanced_parameters.lock_reset_token_to_session";
 
     // Parameter
     private static final String PARAMETER_ACCESS_CODE = "access_code";
@@ -179,6 +181,8 @@ public final class AdminUserService
     private static final String MARK_USER = "user";
     private static final String MARK_SITE_LINK = "site_link";
     private static final String MARK_LOGIN_URL = "login_url";
+    private static final String MARK_RESET_TOKEN_VALIDITY = "reset_token_validity";
+    private static final String MARK_LOCK_RESET_TOKEN_TO_SESSION = "lock_reset_token_to_session";
 
     // Properties
     private static final String PROPERTY_ADMINISTRATOR = "right.administrator";
@@ -454,6 +458,9 @@ public final class AdminUserService
 
             model.put( MARK_FORCE_CHANGE_PASSWORD_REINIT, getBooleanSecurityParameter( DSKEY_FORCE_CHANGE_PASSWORD_REINIT ) );
             model.put( MARK_PASSWORD_MINIMUM_LENGTH, getIntegerSecurityParameter( DSKEY_PASSWORD_MINIMUM_LENGTH ) );
+
+            model.put( MARK_RESET_TOKEN_VALIDITY, getIntegerSecurityParameter( DSKEY_RESET_TOKEN_VALIDITY ) );
+            model.put( MARK_LOCK_RESET_TOKEN_TO_SESSION, getBooleanSecurityParameter( DSKEY_LOCK_RESET_TOKEN_TO_SESSION ) );
 
             if ( bUseAdvancesSecurityParameters )
             {
@@ -1565,6 +1572,23 @@ public final class AdminUserService
         XmlUtil.endElement( sbXml, CONSTANT_XML_USER );
 
         return sbXml.toString( );
+    }
+
+    /**
+     * Get a user reset password token
+     * @param user the user
+     * @param timestamp the timestamp of the token
+     * @param request he request
+     * @return the reset password token
+     */
+    public static String getUserPasswordResetToken( AdminUser user, Date timestamp, HttpServletRequest request )
+    {
+        String strSessionId = null;
+        if ( getBooleanSecurityParameter( DSKEY_LOCK_RESET_TOKEN_TO_SESSION ) )
+        {
+            strSessionId = request.getSession( ).getId( );
+        }
+        return AdminUserHome.getUserPasswordResetToken( user.getUserId( ), timestamp, strSessionId );
     }
 
 }

--- a/src/java/fr/paris/lutece/portal/service/util/CryptoService.java
+++ b/src/java/fr/paris/lutece/portal/service/util/CryptoService.java
@@ -34,9 +34,12 @@
 package fr.paris.lutece.portal.service.util;
 
 import java.io.UnsupportedEncodingException;
-
+import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * The Class CryptoService.
@@ -97,6 +100,47 @@ public final class CryptoService
     public static String getCryptoKey( )
     {
         return AppPropertiesService.getProperty( PROPERTY_CRYPTO_KEY );
+    }
+
+    /**
+     * Get the HmacSHA256 of a message using the app crypto key.
+     * The UTF-8 representation of the key is used.
+     * @param message the message. The mac is calculated from the UTF-8 representation
+     * @return the hmac as hex
+     * @since 6.0.0
+     */
+    public static String hmacSHA256( String message )
+    {
+        byte[] keyBytes;
+        try
+        {
+            keyBytes = getCryptoKey( ).getBytes( "UTF-8" );
+        } catch ( UnsupportedEncodingException e )
+        {
+            throw new AppException( "UTF-8 should be supported", e );
+        }
+        final String strAlg = "HmacSHA256";
+        SecretKeySpec key = new SecretKeySpec( keyBytes, strAlg );
+
+        try
+        {
+            Mac mac = Mac.getInstance( strAlg );
+            mac.init( key );
+
+            return byteToHex( mac.doFinal( message.getBytes( "UTF-8" ) ) );
+        } catch ( NoSuchAlgorithmException e )
+        {
+            throw new AppException( "Could not find " + strAlg + " algorithm which is supposed to be supported by Java", e );
+        } catch ( InvalidKeyException e )
+        {
+            throw new AppException( "The key should be valid", e );
+        } catch ( IllegalStateException e )
+        {
+            throw new AppException( e.getMessage( ), e );
+        } catch ( UnsupportedEncodingException e )
+        {
+            throw new AppException( "UTF-8 should be supported", e );
+        }
     }
 
     /**

--- a/src/java/fr/paris/lutece/portal/web/user/AdminUserJspBean.java
+++ b/src/java/fr/paris/lutece/portal/web/user/AdminUserJspBean.java
@@ -253,6 +253,8 @@ public class AdminUserJspBean extends AdminFeaturesPageJspBean
     private static final String PARAMETER_EXPORT_ATTRIBUTES = "export_attributes";
     private static final String PARAMETER_EXPORT_RIGHTS = "export_rights";
     private static final String PARAMETER_EXPORT_WORKGROUPS = "export_workgroups";
+    private static final String PARAMETER_RESET_TOKEN_VALIDITY = "reset_token_validity";
+    private static final String PARAMETER_LOCK_RESET_TOKEN_TO_SESSION = "lock_reset_token_to_session";
 
     // Jsp url
     private static final String JSP_MANAGE_USER_RIGHTS = "ManageUserRights.jsp";
@@ -1858,6 +1860,9 @@ public class AdminUserJspBean extends AdminFeaturesPageJspBean
 
         // Parameter password length
         AdminUserService.updateSecurityParameter( AdminUserService.DSKEY_PASSWORD_MINIMUM_LENGTH, request.getParameter( PARAMETER_PASSWORD_MINIMUM_LENGTH ) );
+
+        AdminUserService.updateSecurityParameter( AdminUserService.DSKEY_RESET_TOKEN_VALIDITY, request.getParameter( PARAMETER_RESET_TOKEN_VALIDITY ) );
+        AdminUserService.updateSecurityParameter( AdminUserService.DSKEY_LOCK_RESET_TOKEN_TO_SESSION, request.getParameter( PARAMETER_LOCK_RESET_TOKEN_TO_SESSION ) );
 
         boolean bUseAdvancedSecurityParameter = AdminUserService.getBooleanSecurityParameter( AdminUserService.DSKEY_USE_ADVANCED_SECURITY_PARAMETERS );
 

--- a/src/sql/init_db_lutece_core.sql
+++ b/src/sql/init_db_lutece_core.sql
@@ -187,6 +187,8 @@ INSERT INTO core_datastore VALUES ('core.advanced_parameters.access_failures_cap
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.notify_user_password_expired', '');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.password_expired_mail_sender', 'lutece@nowhere.com');
 INSERT INTO core_datastore VALUES ('core.advanced_parameters.password_expired_mail_subject', 'Votre mot de passe a expiré');
+INSERT INTO core_datastore VALUES ('core.advanced_parameters.reset_token_validity', '60');
+INSERT INTO core_datastore VALUES ('core.advanced_parameters.lock_reset_token_to_session', 'false');
 INSERT INTO core_datastore VALUES ('core.backOffice.defaultEditor', 'tinymce');
 INSERT INTO core_datastore VALUES ('core.frontOffice.defaultEditor', 'markitupbbcode');
 INSERT INTO core_datastore VALUES ('core_banned_domain_names', 'yopmail.com');

--- a/src/sql/upgrade/update_db_lutece_core-5.1.1-6.0.0.sql
+++ b/src/sql/upgrade/update_db_lutece_core-5.1.1-6.0.0.sql
@@ -19,3 +19,6 @@ DELETE FROM core_datastore WHERE entity_key = 'core.advanced_parameters.encrypti
 DELETE FROM core_datastore WHERE entity_key = 'core.advanced_parameters.enable_password_encryption';
 
 DELETE FROM core_admin_role_resource WHERE resource_type = 'ADMIN_USER' AND permission = 'MANAGE_ENCRYPTED_PASSWORD';
+
+INSERT INTO core_datastore VALUES ('core.advanced_parameters.reset_token_validity', '60');
+INSERT INTO core_datastore VALUES ('core.advanced_parameters.lock_reset_token_to_session', 'false');

--- a/src/test/java/fr/paris/lutece/portal/service/util/CryptoServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/util/CryptoServiceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2016, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.util;
+
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class CryptoServiceTest extends LuteceTestCase
+{
+    public void testHmacSHA256( )
+    {
+        System.out.println( CryptoService.hmacSHA256( "message" ) );
+    }
+}

--- a/webapp/WEB-INF/conf/lutece.properties
+++ b/webapp/WEB-INF/conf/lutece.properties
@@ -87,7 +87,7 @@ path.plugins.warehouse=/plugins
 ################################################################################
 # JSP admin paths that can be access without authentication
 #
-path.jsp.admin.public.list=adminMessage,adminHeaderSessionless,adminFooter,errorPage,doAdminLogin,adminForgotPassword,doAdminForgotPassword,adminForgotLogin,doAdminForgotLogin,adminFormContact,doAdminFormContact,doModifyDefaultUserPassword
+path.jsp.admin.public.list=adminMessage,adminHeaderSessionless,adminFooter,errorPage,doAdminLogin,adminForgotPassword,doAdminForgotPassword,adminResetPassword,doAdminResetPassword,adminForgotLogin,doAdminForgotLogin,adminFormContact,doAdminFormContact,doModifyDefaultUserPassword
 
 path.jsp.admin.public.adminMessage=jsp/admin/AdminMessage.jsp
 path.jsp.admin.public.adminHeaderSessionless=jsp/admin/AdminHeaderSessionLess.jsp
@@ -96,6 +96,8 @@ path.jsp.admin.public.errorPage=jsp/admin/ErrorPage.jsp
 path.jsp.admin.public.doAdminLogin=jsp/admin/DoAdminLogin.jsp
 path.jsp.admin.public.adminForgotPassword=jsp/admin/AdminForgotPassword.jsp
 path.jsp.admin.public.doAdminForgotPassword=jsp/admin/DoAdminForgotPassword.jsp
+path.jsp.admin.public.adminResetPassword=jsp/admin/AdminResetPassword.jsp
+path.jsp.admin.public.doAdminResetPassword=jsp/admin/DoAdminResetPassword.jsp
 path.jsp.admin.public.adminForgotLogin=jsp/admin/AdminForgotLogin.jsp
 path.jsp.admin.public.doAdminForgotLogin=jsp/admin/DoAdminForgotLogin.jsp
 path.jsp.admin.public.adminFormContact=jsp/admin/AdminFormContact.jsp

--- a/webapp/WEB-INF/templates/admin/admin_email_forgot_password.html
+++ b/webapp/WEB-INF/templates/admin/admin_email_forgot_password.html
@@ -6,12 +6,12 @@
     <#if site_link?has_content>
 		<h2>${site_link}</h2>
 	</#if>
-    #i18n{portal.admin.admin_forgot_password.email.textResetPassword}<br />
-    ----------------------------------------------------------<br />
-    #i18n{portal.admin.admin_forgot_password.email.textNewPassword} : ${new_password}<br />
-    ----------------------------------------------------------<br />
-    #i18n{portal.admin.admin_forgot_password.email.textChangePassword} :<br />
-    <a href="${login_url}">${login_url}</a>
+    <p>${i18n("portal.admin.admin_forgot_password.email.textResetPassword",reset_password_validity)}</p>
+    <#if lock_reset_token_to_session>
+    <p>#i18n{portal.admin.admin_forgot_password.email.textResetPasswordTokenLockedToSession}</p>
+    </#if>
+    <#assign link="${login_url}?user_id=${user_id}&amp;ts=${timestamp}&amp;token=${token}" />
+	<p><a href="${link}">${link}</a></p>
     </body>
 </html>
 

--- a/webapp/WEB-INF/templates/admin/admin_reset_password.html
+++ b/webapp/WEB-INF/templates/admin/admin_reset_password.html
@@ -1,0 +1,73 @@
+<div class="form-box margin" id="reset-password-box">
+    <div class="header bg-blue">
+		<h3>${i18n("portal.admin.admin_reset_password.text")}</h3>
+	</div>	
+	<form method="post" name="reset_password" id="reset_password" action="jsp/admin/DoAdminResetPassword.jsp" class="form-horizontal" role="form">
+		<input type="hidden" name="user_id" value="${user_id!}">
+		<input type="hidden" name="ts" value="${ts!}">
+		<input type="hidden" name="token" value="${token!}">
+		<div class="body bg-gray">
+			<div class="form-group">
+				<label class="control-label col-xs-12 col-sm-3 control-group" for="new_password">${i18n("portal.users.modify_password_default_module.form.password.new")} *</label>
+				<div class="col-sm-9">
+					<div class="input-group">
+						<span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+						<input type="password" class="form-control" name="new_password" id="new_password" required="required" placeholder='${i18n("portal.users.modify_password_default_module.form.password.new")}'>
+					</div>
+				</div>
+			</div>
+			<div class="form-group">
+				<label class="control-label col-xs12 col-sm-3 control-group" for="confirm_new_password">${i18n("portal.users.modify_password_default_module.form.password.confirm")} *</label>
+				<div class="col-xs-12 col-sm-9">
+					<div class="input-group">
+					<span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+					<input type="password" class="form-control" name="confirm_new_password" id="confirm_new_password" required="required" placeholder='${i18n("portal.users.modify_password_default_module.form.password.confirm")}' />
+					</div>
+				</div>
+			</div>
+			<div class="form-group hidden">
+				<label id="status" class="control-label col-xs-12 col-sm-3 control-group" for="">
+					${i18n("portal.users.create_user.passwordComplexity")}
+				</label>
+				<div class="control-label col-xs-12 col-sm-9">
+					<div class="progress">
+						<div id="progressbar" class="progress-bar progress-bar-striped" role="progressbar">
+							<div id="progress"><div id="complexity">0%</div></div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="footer">
+			<div class="text-center">
+				<p>
+					<button type="submit" class="btn btn-primary btn-flat">
+						<span class="fa fa-check"></span> ${i18n("portal.admin.admin_reset_password.buttonSubmit")}
+					</button>  
+					<a href="jsp/admin/AdminLogin.jsp" class="btn btn-default btn-flat" title="#i18n{portal.admin.message.buttonCancel}">
+						<span class="fa fa-remove"></span> ${i18n("portal.admin.message.buttonCancel")}
+					</a>
+				</p>
+				<p>
+					<a class="btn btn-default btn-flat" href="http://fr.lutece.paris.fr" target="_blank" title="#i18n{portal.site.portal_footer.labelPortal}">
+						<img src="images/poweredby.jpg" class="thumbnails" alt="logo lutece" title="Lutece">
+					</a>
+				</p>
+			</div>
+		</div>
+	</form>
+</div>
+<script src="js/jquery.complexify.js"></script>
+<script>
+$(document).ready(function(){
+	$("#status").parent().removeClass("hidden");
+	$("#new_password").complexify({}, function (valid, complexity) {
+		if (!valid) {
+			$('#progressbar').css({'width':complexity + '%'}).removeClass('progress-bar progress-bar-success').addClass('progress-bar progress-bar-danger');
+		} else {
+			$('#progressbar').css({'width':complexity + '%'}).removeClass('progress-bar progress-bar-danger').addClass('progress-bar progress-bar-success');
+			}
+		$('#complexity').html(Math.round(complexity) + '%');
+	});
+});
+</script>

--- a/webapp/WEB-INF/templates/admin/user/advanced_security_parameters.html
+++ b/webapp/WEB-INF/templates/admin/user/advanced_security_parameters.html
@@ -51,6 +51,18 @@
 				<input type="checkbox" name="force_change_password_reinit" id="force_change_password_reinit" value="true" <#if force_change_password_reinit>checked="checked"</#if>>
 			</div>
 		</div>
+		<div class="form-group">
+			<label class="control-label col-xs-12 col-sm-3" for="reset_token_validity">#i18n{portal.users.manage_advanced_parameters.labelResetTokenValidity} :</label>
+			<div class="col-xs-12 col-sm-9">
+				<input type="number" name="reset_token_validity" id="reset_token_validity" value="${reset_token_validity!}" class="form-control" min=0 >
+			</div>
+		</div>
+		<div class="form-group">
+			<label class="control-label col-xs-12 col-sm-3" for="lock_reset_token_to_session">#i18n{portal.users.manage_advanced_parameters.labelLockResetTokenToSession} : </label>
+			<div class="col-xs-12 col-sm-9">
+				<input type="checkbox" name="lock_reset_token_to_session" id="lock_reset_token_to_session" value="true" <#if lock_reset_token_to_session>checked="checked"</#if>>
+			</div>
+		</div>
 		<#if use_advanced_security_parameters>
 			<div class="form-group">
 				<label class="control-label col-xs-12 col-sm-3" for="password_history_size">#i18n{portal.users.manage_advanced_parameters.labelPasswordHistorySize} : </label>

--- a/webapp/jsp/admin/AdminResetPassword.jsp
+++ b/webapp/jsp/admin/AdminResetPassword.jsp
@@ -1,0 +1,9 @@
+<%@ page errorPage="ErrorPage.jsp" %>
+<jsp:include page="AdminHeaderSessionLess.jsp" />
+
+<jsp:useBean id="login" scope="request" class="fr.paris.lutece.portal.web.user.AdminLoginJspBean" />
+
+<%= login.getResetPassword( request ) %>
+
+<%@ include file="AdminFooter.jsp" %>
+

--- a/webapp/jsp/admin/DoAdminResetPassword.jsp
+++ b/webapp/jsp/admin/DoAdminResetPassword.jsp
@@ -1,0 +1,9 @@
+<%@ page errorPage="ErrorPage.jsp" %>
+<jsp:include page="AdminHeaderSessionLess.jsp" />
+
+<jsp:useBean id="login" scope="request" class="fr.paris.lutece.portal.web.user.AdminLoginJspBean" />
+
+<%
+	response.sendRedirect( login.doResetPassword( request ) );
+%>
+


### PR DESCRIPTION
The token is constructed from
 * the current salted and hashed user password
 * the user ID
 * a timestamp
 * optionnaly the browser session ID

The token has a default lifetime of 60 minutes.
It is invalidated if the password is changed and thus can only be used once.
Optionnaly, it can be tied to the browser session, which limit the usefullness of intercepting
the reset email.