### PR TITLE
LUTECE-2017 : Introduce a cache for XPage path (5.x branch)

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/cache/IPathCacheService.java
+++ b/src/java/fr/paris/lutece/portal/service/cache/IPathCacheService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2016, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.cache;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Service interface for XPage path caching
+ */
+public interface IPathCacheService
+{
+
+    /** Bean name */
+    String BEAN_NAME = "pathCacheService";
+
+    /**
+     * Constructs a cache key
+     * @param strXPageName the XPage name
+     * @param nMode the mode
+     * @param request the request
+     * @return the cache key, or <code>null</code> if for instance the cache is not enabled
+     */
+    String getKey( String strXPageName, int nMode, HttpServletRequest request );
+
+    /**
+     * Constructs a cache key
+     * @param strXPageName the XPage name
+     * @param nMode the mode
+     * @param strTitlesUrls list of links (url and titles)
+     * @param request the request the request
+     * @return the cache key, or <code>null</code> if for instance the cache is not enabled
+     */
+    String getKey( String strXPageName, int nMode, String strTitlesUrls, HttpServletRequest request );
+
+    /**
+     * Get the path html from cache
+     * @param strKey the cache key
+     * @return the path html, or <code>null</code> if it's not in cache or the cache is not enabled
+     */
+    String getFromCache( String strKey );
+
+    /**
+     * Put a path in cache
+     * @param strKey the cache key
+     * @param path the path html
+     */
+    void putInCache( String strKey, String path );
+
+}

--- a/src/java/fr/paris/lutece/portal/service/cache/PathCacheService.java
+++ b/src/java/fr/paris/lutece/portal/service/cache/PathCacheService.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2002-2016, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.cache;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang.StringUtils;
+
+import fr.paris.lutece.portal.service.page.PageEvent;
+import fr.paris.lutece.portal.service.page.PageEventListener;
+import fr.paris.lutece.portal.service.page.PageService;
+import fr.paris.lutece.portal.web.constants.Parameters;
+
+/**
+ * XPage path cache service
+ */
+public class PathCacheService extends AbstractCacheableService implements IPathCacheService, PageEventListener
+{
+
+    /**
+     * Constructor
+     */
+    PathCacheService( )
+    {
+        initCache( );
+        PageService.addPageEventListener( this );
+    }
+
+    @Override
+    public String getName( )
+    {
+        return IPathCacheService.BEAN_NAME;
+    }
+
+    @Override
+    public String getKey( String strXPageName, int nMode, HttpServletRequest request )
+    {
+        return getKey( strXPageName, nMode, null, request );
+    }
+
+    @Override
+    public String getKey( String strXPageName, int nMode, String strTitlesUrls, HttpServletRequest request )
+    {
+        if ( !isCacheEnable( ) )
+        {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder( );
+        builder.append( "[XPageName:" ).append( strXPageName ).append( ']' );
+        builder.append( "[mode:" ).append( nMode ).append( ']' );
+        if ( strTitlesUrls != null )
+        {
+            builder.append( "[titleUrls:" ).append( strTitlesUrls ).append( ']' );
+        }
+        if ( request != null )
+        {
+            builder.append( "[locale:" ).append( request.getLocale( ) ).append( ']' );
+            String strPageId = request.getParameter( Parameters.PAGE_ID );
+            if ( StringUtils.isNotBlank( strPageId ) )
+            {
+                builder.append( '[' ).append( Parameters.PAGE_ID ).append( ':' ).append( strPageId ).append( ']' );
+            }
+            String strPortletId = request.getParameter( Parameters.PORTLET_ID );
+            if ( StringUtils.isNotBlank( strPortletId ) )
+            {
+                builder.append( '[' ).append( Parameters.PORTLET_ID ).append( ':' ).append( strPortletId ).append( ']' );
+            }
+        }
+        return builder.toString( );
+    }
+
+    @Override
+    public String getFromCache( String strKey )
+    {
+        return ( String ) super.getFromCache( strKey );
+    }
+
+    @Override
+    public void putInCache( String strKey, String path )
+    {
+        super.putInCache( strKey, path );
+    }
+
+    @Override
+    public void processPageEvent( PageEvent event )
+    {
+        if ( isCacheEnable( ) && event.getEventType( ) != PageEvent.PAGE_CREATED )
+        {
+            // some cached paths might contain page info that need invalidation, but not for
+            // a page which was just created
+            resetCache( );
+        }
+    }
+
+}

--- a/src/java/fr/paris/lutece/portal/service/portal/PortalService.java
+++ b/src/java/fr/paris/lutece/portal/service/portal/PortalService.java
@@ -43,6 +43,7 @@ import fr.paris.lutece.portal.business.style.ModeHome;
 import fr.paris.lutece.portal.business.stylesheet.StyleSheet;
 import fr.paris.lutece.portal.service.cache.CacheService;
 import fr.paris.lutece.portal.service.cache.CacheableService;
+import fr.paris.lutece.portal.service.cache.IPathCacheService;
 import fr.paris.lutece.portal.service.content.ContentService;
 import fr.paris.lutece.portal.service.content.PageData;
 import fr.paris.lutece.portal.service.datastore.DatastoreService;
@@ -426,6 +427,17 @@ public final class PortalService
      */
     public static String getXPagePathContent( String strXPageName, int nMode, HttpServletRequest request )
     {
+        final IPathCacheService pathCacheService = SpringContextService.getBean( IPathCacheService.BEAN_NAME );
+
+        final String strKey = pathCacheService.getKey( strXPageName, nMode, request );
+
+        String strRes = pathCacheService.getFromCache( strKey );
+
+        if ( strRes != null )
+        {
+            return strRes;
+        }
+
         // Added in v1.3
         StyleSheet xslSource;
 
@@ -485,7 +497,11 @@ public final class PortalService
         String strPath = xmlTransformerService.transformBySourceWithXslCache( strXml, xslSource, mapXslParams,
                 outputProperties );
 
-        return formatPath( strPath, nMode, request );
+        strRes = formatPath( strPath, nMode, request );
+
+        pathCacheService.putInCache( strKey, strRes );
+
+        return strRes;
     }
 
     /**
@@ -651,6 +667,17 @@ public final class PortalService
     public static String getXPagePathContent( String strXPageName, int nMode, String strTitlesUrls,
         HttpServletRequest request )
     {
+        final IPathCacheService pathCacheService = SpringContextService.getBean( IPathCacheService.BEAN_NAME );
+
+        final String strKey = pathCacheService.getKey( strXPageName, nMode, strTitlesUrls, request );
+
+        String strRes = pathCacheService.getFromCache( strKey );
+
+        if ( strRes != null )
+        {
+            return strRes;
+        }
+
         // Selection of the XSL stylesheet
         StyleSheet xslSource;
 
@@ -679,7 +706,11 @@ public final class PortalService
         XmlTransformerService xmlTransformerService = new XmlTransformerService(  );
         String strPath = xmlTransformerService.transformBySourceWithXslCache( strXml, xslSource, mapXslParams );
 
-        return formatPath( strPath, nMode, request );
+        strRes = formatPath( strPath, nMode, request );
+
+        pathCacheService.putInCache( strKey, strRes );
+
+        return strRes;
     }
 
     /**

--- a/src/test/java/fr/paris/lutece/portal/service/cache/PathCacheServiceDisabledTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/cache/PathCacheServiceDisabledTest.java
@@ -1,0 +1,79 @@
+package fr.paris.lutece.portal.service.cache;
+
+import java.util.List;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import fr.paris.lutece.portal.business.page.Page;
+import fr.paris.lutece.portal.service.page.PageEvent;
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class PathCacheServiceDisabledTest extends LuteceTestCase
+{
+    IPathCacheService service;
+    boolean bEnabled;
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        service = null;
+        List<CacheableService> serviceList = CacheService.getCacheableServicesList( );
+        for ( CacheableService aService : serviceList )
+        {
+            if ( aService instanceof IPathCacheService )
+            {
+                service = ( IPathCacheService ) aService;
+                bEnabled = aService.isCacheEnable( );
+                aService.enableCache( false );
+                break;
+            }
+        }
+        assertNotNull( service );
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        List<CacheableService> serviceList = CacheService.getCacheableServicesList( );
+        for ( CacheableService aService : serviceList )
+        {
+            if ( aService == service )
+            {
+                aService.enableCache( bEnabled );
+                break;
+            }
+        }
+        service = null;
+        super.tearDown( );
+    }
+
+    public void testGetKey( )
+    {
+        assertNull( service.getKey( "junit", 0, new MockHttpServletRequest( ) ) );
+        assertNull( service.getKey( "junit", 0, "junit", new MockHttpServletRequest( ) ) );
+    }
+
+    public void testPutAndGetFromCache( )
+    {
+        service.putInCache( null, "junit" );
+        String key = service.getKey( "junit", 0, null );
+        service.putInCache( key, "junit" );
+        assertNull( service.getFromCache( key ) );
+        assertNull( service.getFromCache( null ) );
+        assertNull( service.getFromCache( "NotInCache" ) );
+    }
+
+    public void testProcessPageEvent( )
+    {
+        String key = service.getKey( "junit", 0, null );
+        for ( int nEventType : new int[] { PageEvent.PAGE_CONTENT_MODIFIED, PageEvent.PAGE_CREATED, PageEvent.PAGE_DELETED, PageEvent.PAGE_MOVED, PageEvent.PAGE_STATE_CHANGED } )
+        {
+            service.putInCache( key, "junit" );
+            PageEvent event = new PageEvent( new Page( ), nEventType );
+            ( ( PathCacheService ) service ).processPageEvent( event );
+            assertNull( service.getFromCache( key ) );
+        }
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/portal/service/cache/PathCacheServiceEnabledTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/cache/PathCacheServiceEnabledTest.java
@@ -1,0 +1,209 @@
+package fr.paris.lutece.portal.service.cache;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.Set;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import fr.paris.lutece.portal.business.page.Page;
+import fr.paris.lutece.portal.service.page.PageEvent;
+import fr.paris.lutece.portal.service.page.PageService;
+import fr.paris.lutece.portal.service.portal.PortalService;
+import fr.paris.lutece.portal.service.spring.SpringContextService;
+import fr.paris.lutece.portal.web.constants.Parameters;
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class PathCacheServiceEnabledTest extends LuteceTestCase
+{
+
+    private static final String BEAN_PAGE_SERVICE = "pageService";
+
+    IPathCacheService service;
+    boolean bEnabled;
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        service = null;
+        List<CacheableService> serviceList = CacheService.getCacheableServicesList( );
+        for ( CacheableService aService : serviceList )
+        {
+            if ( aService instanceof IPathCacheService )
+            {
+                service = ( IPathCacheService ) aService;
+                bEnabled = aService.isCacheEnable( );
+                aService.enableCache( true );
+                aService.resetCache( );
+                break;
+            }
+        }
+        assertNotNull( service );
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        List<CacheableService> serviceList = CacheService.getCacheableServicesList( );
+        for ( CacheableService aService : serviceList )
+        {
+            if ( aService == service )
+            {
+                aService.resetCache( );
+                aService.enableCache( bEnabled );
+                break;
+            }
+        }
+        service = null;
+        super.tearDown( );
+    }
+
+    public void testGetKey( )
+    {
+        Set<String> keys = new HashSet<>( );
+        for ( String xpageName : new String[] { "name", "name2" } )
+        {
+            for ( int mode : new int[] { 0, 1, 2} )
+            {
+                String key = service.getKey( xpageName, mode, null );
+                checkKey( keys, key );
+                MockHttpServletRequest request = new MockHttpServletRequest( );
+                request.addPreferredLocale( Locale.FRANCE );
+                key = service.getKey( xpageName, mode, request );
+                checkKey( keys, key );
+                request = new MockHttpServletRequest( );
+                request.addPreferredLocale( Locale.ITALY );
+                key = service.getKey( xpageName, mode, request );
+                checkKey( keys, key );
+                request = new MockHttpServletRequest( );
+                request.addParameter( Parameters.PAGE_ID, "1" );
+                key = service.getKey( xpageName, mode, request );
+                checkKey( keys, key );
+                request = new MockHttpServletRequest( );
+                request.addParameter( Parameters.PAGE_ID, "2" );
+                key = service.getKey( xpageName, mode, request );
+                checkKey( keys, key );
+                request = new MockHttpServletRequest( );
+                request.addParameter( Parameters.PORTLET_ID, "1" );
+                key = service.getKey( xpageName, mode, request );
+                checkKey( keys, key );
+                request = new MockHttpServletRequest( );
+                request.addParameter( Parameters.PORTLET_ID, "2" );
+                key = service.getKey( xpageName, mode, request );
+                checkKey( keys, key );
+            }
+        }
+    }
+
+    public void testGetKeyWithTitleUrls( )
+    {
+        Set<String> keys = new HashSet<>( );
+        for ( String xpageName : new String[] { "name", "name2" } )
+        {
+            for ( int mode : new int[] { 0, 1, 2} )
+            {
+                for ( String titleUrls : new String[] {null, "title1", "title2" } )
+                {
+                    String key = service.getKey( xpageName, mode, titleUrls, null );
+                    checkKey( keys, key );
+                    MockHttpServletRequest request = new MockHttpServletRequest( );
+                    request.addPreferredLocale( Locale.FRANCE );
+                    key = service.getKey( xpageName, mode, titleUrls, request );
+                    checkKey( keys, key );
+                    request = new MockHttpServletRequest( );
+                    request.addPreferredLocale( Locale.ITALY );
+                    key = service.getKey( xpageName, mode, titleUrls, request );
+                    checkKey( keys, key );
+                    request = new MockHttpServletRequest( );
+                    request.addParameter( Parameters.PAGE_ID, "1" );
+                    key = service.getKey( xpageName, mode, titleUrls, request );
+                    checkKey( keys, key );
+                    request = new MockHttpServletRequest( );
+                    request.addParameter( Parameters.PAGE_ID, "2" );
+                    key = service.getKey( xpageName, mode, titleUrls, request );
+                    checkKey( keys, key );
+                    request = new MockHttpServletRequest( );
+                    request.addParameter( Parameters.PORTLET_ID, "1" );
+                    key = service.getKey( xpageName, mode, titleUrls, request );
+                    checkKey( keys, key );
+                    request = new MockHttpServletRequest( );
+                    request.addParameter( Parameters.PORTLET_ID, "2" );
+                    key = service.getKey( xpageName, mode, titleUrls, request );
+                    checkKey( keys, key );
+                }
+            }
+        }
+    }
+
+    public void testPutAndGetFromCache( )
+    {
+        service.putInCache( null, "junit" );
+        String key = service.getKey( "junit", 0, null );
+        service.putInCache( key, "junit" );
+        assertEquals( "junit", service.getFromCache( key ) );
+        assertNull( service.getFromCache( null ) );
+        assertNull( service.getFromCache( "NotInCache" ) );
+    }
+
+    public void testProcessPageEvent( )
+    {
+        String key = service.getKey( "junit", 0, null );
+        service.putInCache( key, "junit" );
+        PageEvent event = new PageEvent( new Page( ), PageEvent.PAGE_CREATED );
+        ( ( PathCacheService ) service ).processPageEvent( event );
+        assertEquals( "junit", service.getFromCache( key ) );
+        for ( int nEventType : new int[] { PageEvent.PAGE_CONTENT_MODIFIED, PageEvent.PAGE_DELETED, PageEvent.PAGE_MOVED, PageEvent.PAGE_STATE_CHANGED } )
+        {
+            service.putInCache( key, "junit" );
+            event = new PageEvent( new Page( ), nEventType );
+            ( ( PathCacheService ) service ).processPageEvent( event );
+            assertNull( service.getFromCache( key ) );
+        }
+    }
+
+    public void testRegisteredPageEventListener( )
+    {
+        String key = service.getKey( "junit", 0, null );
+        service.putInCache( key, "junit" );
+        PageService pageService = SpringContextService.getBean( BEAN_PAGE_SERVICE );
+        Page page = new Page( );
+        page.setName( getRandomName( ) );
+        page.setDescription( page.getName( ) );
+        page.setParentPageId( PortalService.getRootPageId( ) );
+        pageService.createPage( page );
+        try
+        {
+            // FIXME : change when LUTECE-1834 Adding or removing a page blows up all caches
+            // is fixed
+            //assertEquals( "junit", service.getFromCache( key ) );
+            assertNull( service.getFromCache( key ) );
+            service.putInCache( key, "junit" );
+            page.setDescription( page.getName( ) + page.getName( ) );
+            pageService.updatePage( page );
+            assertNull( service.getFromCache( key ) );
+            service.putInCache( key, "junit" );
+        } finally {
+            pageService.removePage( page.getId( ) );
+            assertNull( service.getFromCache( key ) );
+        }
+    }
+
+    private String getRandomName( )
+    {
+        Random rand = new SecureRandom( );
+        BigInteger bigInt = new BigInteger( 128, rand );
+        return "junit" + bigInt.toString( 36 );
+    }
+
+    private void checkKey( Set<String> keys, String key )
+    {
+        assertNotNull( key );
+        assertFalse( keys.contains( key ) );
+        keys.add( key );
+    }
+}

--- a/src/test/java/fr/paris/lutece/portal/service/portal/PortalServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/portal/PortalServiceTest.java
@@ -33,19 +33,144 @@
  */
 package fr.paris.lutece.portal.service.portal;
 
-import fr.paris.lutece.test.LuteceTestCase;
-import fr.paris.lutece.test.MokeHttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+import java.util.Scanner;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import fr.paris.lutece.portal.business.page.Page;
+import fr.paris.lutece.portal.service.cache.CacheService;
+import fr.paris.lutece.portal.service.cache.CacheableService;
+import fr.paris.lutece.portal.service.cache.IPathCacheService;
+import fr.paris.lutece.portal.service.page.IPageService;
+import fr.paris.lutece.portal.service.spring.SpringContextService;
+import fr.paris.lutece.portal.web.constants.Parameters;
+import fr.paris.lutece.test.LuteceTestCase;
 
 public class PortalServiceTest extends LuteceTestCase
 {
-    public void testGetDefaultPage(  )
+    private static final int MODE_NORMAL = 0;
+    private static final int MODE_ADMIN = 1;
+
+    IPathCacheService pathCacheService;
+    boolean bPathCacheServiceEnabled;
+
+    @Override
+    protected void setUp( ) throws Exception
     {
-        HttpServletRequest request = new MokeHttpServletRequest(  );
+        super.setUp( );
+        pathCacheService = null;
+        List<CacheableService> serviceList = CacheService.getCacheableServicesList( );
+        for ( CacheableService aService : serviceList )
+        {
+            if ( aService instanceof IPathCacheService )
+            {
+                pathCacheService = ( IPathCacheService ) aService;
+                bPathCacheServiceEnabled = aService.isCacheEnable( );
+                aService.enableCache( true );
+                aService.resetCache( );
+                break;
+            }
+        }
+        assertNotNull( pathCacheService );
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        List<CacheableService> serviceList = CacheService.getCacheableServicesList( );
+        for ( CacheableService aService : serviceList )
+        {
+            if ( aService == pathCacheService )
+            {
+                aService.resetCache( );
+                aService.enableCache( bPathCacheServiceEnabled );
+                break;
+            }
+        }
+        pathCacheService = null;
+        super.tearDown( );
+    }
+
+    public void testGetDefaultPage( )
+    {
+        HttpServletRequest request = new MockHttpServletRequest( );
         int nMode = 0;
 
         // PortalService.getDefaultPage( request, nMode );
+    }
+
+    public void testGetXPagePathContent( ) throws IOException
+    {
+        MockHttpServletRequest request = new MockHttpServletRequest( );
+        String strPath_normal = PortalService.getXPagePathContent( "junit", MODE_NORMAL, request );
+        assertEquals( loadExpected( "getXPagePathContent_1.txt" ), strPath_normal );
+        assertSame( strPath_normal, PortalService.getXPagePathContent( "junit", MODE_NORMAL, request ) );
+
+        String strPath_admin = PortalService.getXPagePathContent( "junit", MODE_ADMIN, request );
+        assertEquals( loadExpected( "getXPagePathContent_1.txt" ), strPath_normal );
+        assertNotSame( strPath_admin, strPath_normal );
+        assertSame( strPath_admin, PortalService.getXPagePathContent( "junit", MODE_ADMIN, request ) );
+
+        int nPageId = createPage( );
+        try
+        {
+            MockHttpServletRequest request2 = new MockHttpServletRequest( );
+            request2.setParameter( Parameters.PAGE_ID, Integer.toString( nPageId ) );
+            String strPath_pageid = PortalService.getXPagePathContent( "junit", MODE_NORMAL, request2 );
+            assertEquals( loadExpected( "getXPagePathContent_2.txt" ), strPath_pageid );
+            assertNotSame( strPath_pageid, strPath_normal );
+            assertNotSame( strPath_pageid, strPath_admin );
+            assertSame( strPath_pageid, PortalService.getXPagePathContent( "junit", MODE_NORMAL, request2 ) );
+        } finally
+        {
+            removePage( nPageId );
+        }
+    }
+
+    public void testGetXPagePathContentWithTitleUrls( ) throws IOException
+    {
+        String strTitleUrls = "<page><page-id>junit</page-id><page-name>junit</page-name></page>";
+        MockHttpServletRequest request = new MockHttpServletRequest( );
+        String strPath_normal = PortalService.getXPagePathContent( "junit", MODE_NORMAL, strTitleUrls, request );
+        assertEquals( loadExpected( "getXPagePathContentWithTitleUrls_1.txt" ), strPath_normal );
+        assertSame( strPath_normal, PortalService.getXPagePathContent( "junit", MODE_NORMAL, strTitleUrls, request ) );
+
+        String strPath_admin = PortalService.getXPagePathContent( "junit", MODE_ADMIN, strTitleUrls, request );
+        assertEquals( loadExpected( "getXPagePathContentWithTitleUrls_1.txt" ), strPath_normal );
+        assertNotSame( strPath_admin, strPath_normal );
+        assertSame( strPath_admin, PortalService.getXPagePathContent( "junit", MODE_ADMIN, strTitleUrls, request ) );
+    }
+
+    private void removePage( int nPageId )
+    {
+        IPageService pageService = SpringContextService.getBean( "pageService" );
+        pageService.removePage( nPageId );
+    }
+
+    private int createPage( )
+    {
+        IPageService pageService = SpringContextService.getBean( "pageService" );
+        Page page = new Page( );
+        page.setName( "junit2" );
+        page.setDescription( "junit2" );
+        page.setParentPageId( PortalService.getRootPageId( ) );
+        pageService.createPage( page );
+        return page.getId( );
+    }
+
+    private String loadExpected( String strExpectedFileName ) throws IOException
+    {
+        try ( Scanner s = new Scanner(
+                this.getClass( ).getResourceAsStream( this.getClass( ).getSimpleName( ) + "_" + strExpectedFileName ),
+                "UTF-8" ) )
+        {
+            Scanner delimited = s.useDelimiter( "\\A" );
+            return delimited.hasNext( ) ? delimited.next( ) : "";
+        }
+
     }
 }

--- a/src/test/resources/fr/paris/lutece/portal/service/portal/PortalServiceTest_getXPagePathContentWithTitleUrls_1.txt
+++ b/src/test/resources/fr/paris/lutece/portal/service/portal/PortalServiceTest_getXPagePathContentWithTitleUrls_1.txt
@@ -1,0 +1,7 @@
+<ul class="breadcrumb">
+	<li><?xml version="1.0" encoding="UTF-8"?>
+<a href="jsp/site/Portal.jsp?page_id=1" target="_top">Home</a> &gt;
+		
+<a href="jsp/site/Portal.jsp?page_id=junit" target="_top">junit</a> &gt;
+		</li>
+</ul>

--- a/src/test/resources/fr/paris/lutece/portal/service/portal/PortalServiceTest_getXPagePathContent_1.txt
+++ b/src/test/resources/fr/paris/lutece/portal/service/portal/PortalServiceTest_getXPagePathContent_1.txt
@@ -1,0 +1,7 @@
+<ul class="breadcrumb">
+	<li>
+<a href="jsp/site/Portal.jsp?page_id=1" target="_top">Home</a> &gt;
+		
+junit
+</li>
+</ul>

--- a/src/test/resources/fr/paris/lutece/portal/service/portal/PortalServiceTest_getXPagePathContent_2.txt
+++ b/src/test/resources/fr/paris/lutece/portal/service/portal/PortalServiceTest_getXPagePathContent_2.txt
@@ -1,0 +1,9 @@
+<ul class="breadcrumb">
+	<li>
+<a href="jsp/site/Portal.jsp?page_id=1" target="_top">Home</a> &gt;
+		
+<a href="jsp/site/Portal.jsp?page_id=0" target="_top">null</a> &gt;
+		
+junit
+</li>
+</ul>

--- a/webapp/WEB-INF/conf/caches.dat
+++ b/webapp/WEB-INF/conf/caches.dat
@@ -19,3 +19,4 @@ BaseUserPreferencesCacheService.enabled=1
 BaseUserPreferencesCacheService.maxElementsInMemory=1000
 LuteceUserCacheService.enabled=1
 LuteceUserCacheService.maxElementsInMemory=1000
+pathCacheService.enabled=1

--- a/webapp/WEB-INF/conf/core_context.xml
+++ b/webapp/WEB-INF/conf/core_context.xml
@@ -39,6 +39,7 @@
             </list>
         </property>
     </bean>
+    <bean id="pathCacheService" class="fr.paris.lutece.portal.service.cache.PathCacheService" />
 
     <bean id="pageCacheService" class="fr.paris.lutece.portal.service.page.PageCacheService" />
     <bean id="portletCacheService" class="fr.paris.lutece.portal.service.page.PortletCacheService" />


### PR DESCRIPTION
Cf. PR https://github.com/lutece-platform/lutece-core/pull/73

The cache is exposed via Spring, which allow plugins to replace the implementation should
the need arise. For instance, if a site uses a page_path.html template which depends on
a PageInclude which itself depends on request characteristics, it could override the implementation
to alter the cache key generation.

Tests suggest a ~6x increase in performances when the cache is enabled. Enable it by default.

Tested with a minimal XPage and the following command:
ab -c 2 -n 50000 http://localhost:8080/lutece/jsp/site/Portal.jsp?page=test

Path Cache enabled, datastore cache enabled, treemenu include disabled, XPage without extendedPathLabel
Requests per second: 4165.80 #/sec

Path Cache disabled, datastore cache enabled, treemenu include disabled, XPage without extendedPathLabel
Requests per second: 697.99 #/sec

Path Cache enabled, datastore cache enabled, treemenu include disabled, XPage with extendedPathLabel
Requests per second: 4122.74 #/sec

Path Cache disabled, datastore cache enabled, treemenu include disabled, XPage with extendedPathLabel
Requests per second: 706.21 #/sec