### PR TITLE
LUTECE-2074 : Give the CacheManager a stable name.

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/cache/CacheService.java
+++ b/src/java/fr/paris/lutece/portal/service/cache/CacheService.java
@@ -91,6 +91,7 @@ public final class CacheService
     private static final String DISABLED = "0";
     private static final String NOT_FOUND = "NOT FOUND";
     private static final String PREFIX_DEFAULT = "lutece.cache.default";
+    private static final String LUTECE_CACHEMANAGER_NAME = "LuteceCacheManager";
     private static CacheService _singleton;
     private static CacheManager _manager;
 
@@ -136,6 +137,7 @@ public final class CacheService
     private void init( )
     {
         _manager = CacheManager.create( );
+        _manager.setName( LUTECE_CACHEMANAGER_NAME );
         loadDefaults( );
         loadCachesConfig( );
 


### PR DESCRIPTION
This makes following a cache statistics via JMX across restarts easy.