### PR TITLE
LUTECE-2085 : Make daemons reactive

### DIFF
--- a/src/java/fr/paris/lutece/portal/resources/system_messages.properties
+++ b/src/java/fr/paris/lutece/portal/resources/system_messages.properties
@@ -156,6 +156,7 @@ manage_daemons.columnTitleInterval=Interval (sec.)
 manage_daemons.columnTitleActions=Actions
 manage_daemons.buttonStart=Start
 manage_daemons.buttonStop=Stop
+manage_daemons.buttonRun=Run now
 manage_daemons.buttonUpdateInterval=Modify Interval
 manage_daemons.unit.sec=s
 manage_daemons.unit.mn=mn

--- a/src/java/fr/paris/lutece/portal/resources/system_messages_fr.properties
+++ b/src/java/fr/paris/lutece/portal/resources/system_messages_fr.properties
@@ -155,6 +155,7 @@ manage_daemons.columnTitleLastRun=Derni\u00e8re ex\u00e9cution
 manage_daemons.columnTitleActions=Actions
 manage_daemons.buttonStart=D\u00e9marrer
 manage_daemons.buttonStop=Arr\u00eater
+manage_daemons.buttonRun=Ex\u00e9cuter maintenant
 manage_daemons.buttonUpdateInterval=Modifier l'intervalle de passage du daemon
 manage_daemons.unit.sec=s
 manage_daemons.unit.mn=mn

--- a/src/java/fr/paris/lutece/portal/service/daemon/AppDaemonService.java
+++ b/src/java/fr/paris/lutece/portal/service/daemon/AppDaemonService.java
@@ -234,7 +234,27 @@ public final class AppDaemonService
      */
     public static boolean signalDaemon( String strDaemonKey )
     {
-        return _executor.enqueue( _mapDaemonEntries.get( strDaemonKey ) );
+        return signalDaemon( strDaemonKey, 0L, TimeUnit.MILLISECONDS );
+    }
+
+    /**
+     * Signal a daemon for execution in the immediate future.
+     * <p>
+     * This can fail is resources are limited, which should be exceptional.
+     *
+     * @param strDaemonKey
+     *            the daemon key
+     * @param nDelay
+     *            the delay before execution
+     * @param unit
+     *            the unit of <code>nDelay</code> argument
+     * @return <code>true</code> if the daemon was successfully signaled,
+     *         <code>false</code> otherwise
+     * @since 6.0.0
+     */
+    public static boolean signalDaemon( String strDaemonKey, long nDelay, TimeUnit unit )
+    {
+        return _executor.enqueue( _mapDaemonEntries.get( strDaemonKey ), nDelay, unit );
     }
 
     /**

--- a/src/java/fr/paris/lutece/portal/service/daemon/DaemonScheduler.java
+++ b/src/java/fr/paris/lutece/portal/service/daemon/DaemonScheduler.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2002-2017, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.daemon;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import fr.paris.lutece.portal.service.util.AppLogService;
+import fr.paris.lutece.portal.service.util.AppPropertiesService;
+
+/**
+ * Daemon scheduler.
+ * <p>
+ * Responsible for ensuring on demand or timely daemon execution. Starts a
+ * thread which monitor the queue for daemons to execute. A {@link Timer}
+ * handles repeating daemons runs.
+ * 
+ * <p>
+ * Daemon run requests are coalesced. If a daemon is already running when a
+ * request comes, a new run is scheduled right after the current run ends.
+ */
+class DaemonScheduler implements Runnable, IDaemonScheduler
+{
+    private static final String PROPERTY_MAX_AWAIT_TERMINATION_DELAY = "daemon.maxAwaitTerminationDelay";
+
+    private final BlockingQueue<DaemonEntry> _queue;
+    private final ExecutorService _executor;
+    private final Thread _coordinatorThread;
+    private final Timer _scheduledDaemonsTimer;
+    private final Map<String, RunnableWrapper> _executingDaemons;
+    private final Map<String, DaemonTimerTask> _scheduledDaemons;
+
+    /**
+     * Constructor
+     * 
+     * @param queue
+     *            the queue where daemon execution requests are stored
+     * @param executor
+     *            the executor service handling the execution of daemons
+     */
+    public DaemonScheduler( BlockingQueue<DaemonEntry> queue, ExecutorService executor )
+    {
+        _queue = queue;
+        _executor = executor;
+        _scheduledDaemonsTimer = new Timer( "Lutece-Daemons-Scheduled-Timer-Thread", true );
+        _executingDaemons = new HashMap<>( );
+        _scheduledDaemons = new HashMap<>( );
+        _coordinatorThread = new Thread( this, "Lutece-Daemons-Coordinator" );
+        _coordinatorThread.setDaemon( true );
+        _coordinatorThread.start( );
+    }
+
+    @Override
+    public boolean enqueue( DaemonEntry entry )
+    {
+        boolean queued = _queue.offer( entry );
+        if ( !queued )
+        {
+            AppLogService.error( "Failed to enqueue a run of daemon " + entry.getId( ) );
+        }
+        return queued;
+    }
+
+    @Override
+    public void schedule( DaemonEntry entry, long nInitialDelay, TimeUnit unit )
+    {
+        synchronized ( _scheduledDaemons )
+        {
+            if ( _scheduledDaemons.containsKey( entry.getId( ) ) )
+            {
+                AppLogService.error( "Daemon " + entry.getId( ) + " already scheduled, not scheduling again" );
+            }
+            else
+            {
+
+                DaemonTimerTask daemonTimerTask = new DaemonTimerTask( entry );
+                _scheduledDaemonsTimer.scheduleAtFixedRate( daemonTimerTask, unit.toMillis( nInitialDelay ),
+                        entry.getInterval( ) * 1000 );
+                _scheduledDaemons.put( entry.getId( ), daemonTimerTask );
+            }
+        }
+
+    }
+
+    @Override
+    public void unSchedule( DaemonEntry entry )
+    {
+        synchronized ( _scheduledDaemons )
+        {
+            DaemonTimerTask daemonTimerTask = _scheduledDaemons.get( entry.getId( ) );
+            if ( daemonTimerTask == null )
+            {
+                AppLogService.error( "Could not unschedule daemon " + entry.getId( ) + " which was not scheduled" );
+            }
+            else
+            {
+                daemonTimerTask.cancel( );
+                _scheduledDaemonsTimer.purge( );
+                _scheduledDaemons.remove( entry.getId( ) );
+            }
+        }
+    }
+
+    @Override
+    public void run( )
+    {
+        // use a set to coalesce daemon signaling
+        Set<DaemonEntry> queued = new HashSet<>( );
+        do
+        {
+            try
+            {
+                // collect signaled daemons
+                queued.add( _queue.take( ) );
+                _queue.drainTo( queued );
+            }
+            catch ( InterruptedException e )
+            {
+                // We were asked to stop
+                break;
+            }
+            // execute them
+            for ( DaemonEntry entry : queued )
+            {
+                RunnableWrapper runnable = null;
+                synchronized ( _executingDaemons )
+                {
+                    runnable = _executingDaemons.get( entry.getId( ) );
+                    if ( runnable != null )
+                    {
+                        // already executing; schedule a new run after this one
+                        runnable.shouldEnqueueAgain( );
+                        runnable = null;
+                    }
+                    else
+                    {
+                        runnable = new RunnableWrapper( entry );
+                        _executingDaemons.put( entry.getId( ), runnable );
+                    }
+                }
+                if ( runnable != null )
+                {
+                    _executor.execute( runnable );
+                }
+            }
+            // prepare next iteration
+            queued.clear( );
+        }
+        while ( !Thread.interrupted( ) );
+    }
+
+    @Override
+    public void shutdown( )
+    {
+        int maxAwaitTerminationDelay = AppPropertiesService.getPropertyInt( PROPERTY_MAX_AWAIT_TERMINATION_DELAY, 15 );
+        AppLogService
+                .info( "Lutece daemons scheduler stop requested : trying to terminate gracefully daemons list (max wait "
+                        + maxAwaitTerminationDelay + " s)." );
+        _scheduledDaemonsTimer.cancel( );
+        _scheduledDaemonsTimer.purge( );
+        _coordinatorThread.interrupt( );
+        _executor.shutdown( );
+        try
+        {
+            if ( _executor.awaitTermination( maxAwaitTerminationDelay, TimeUnit.SECONDS ) )
+            {
+                AppLogService.info( "All daemons shutdown successfully." );
+            }
+            else
+            {
+                AppLogService.info( "Some daemons are still running, trying to interrupt them..." );
+                _executor.shutdownNow( );
+
+                if ( _executor.awaitTermination( 1, TimeUnit.SECONDS ) )
+                {
+                    AppLogService.info( "All running daemons successfully interrupted." );
+                }
+                else
+                {
+                    AppLogService.error( "Interrupt failed; daemons still running." );
+                }
+            }
+        }
+        catch ( InterruptedException e )
+        {
+            AppLogService.error( "Interruped while waiting for daemons termination", e );
+        }
+    }
+
+    /**
+     * Wrapper for the daemon Runnable which can enqueue a new run when
+     * execution completes
+     */
+    private final class RunnableWrapper implements Runnable
+    {
+
+        private final DaemonEntry _entry;
+        private volatile boolean _bShouldEnqueueAgain;
+
+        /**
+         * @param entry
+         *            the wrapped DaemonEntry
+         */
+        public RunnableWrapper( DaemonEntry entry )
+        {
+            _entry = entry;
+        }
+
+        /**
+         * Signals that an execution of the daemon should be enqueued on
+         * completion
+         */
+        public void shouldEnqueueAgain( )
+        {
+            _bShouldEnqueueAgain = true;
+        }
+
+        @Override
+        public void run( )
+        {
+            try
+            {
+                _entry.getDaemonThread( ).run( );
+            }
+            finally
+            {
+                synchronized ( _executingDaemons )
+                {
+                    _executingDaemons.remove( _entry.getId( ) );
+                }
+                if ( _bShouldEnqueueAgain )
+                {
+                    enqueue( _entry );
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Timer task to enqueue daemon runs
+     */
+    private final class DaemonTimerTask extends TimerTask
+    {
+
+        private final DaemonEntry _entry;
+
+        /**
+         * @param entry
+         *            the daemon
+         */
+        public DaemonTimerTask( DaemonEntry entry )
+        {
+            _entry = entry;
+        }
+
+        @Override
+        public void run( )
+        {
+            enqueue( _entry );
+        }
+
+    }
+
+}

--- a/src/java/fr/paris/lutece/portal/service/daemon/IDaemonScheduler.java
+++ b/src/java/fr/paris/lutece/portal/service/daemon/IDaemonScheduler.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2017, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.daemon;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Daemon scheduler. Responsible for ensuring on demand or timely daemon
+ * execution.
+ */
+public interface IDaemonScheduler
+{
+
+    /** The bean name */
+    String BEAN_NAME = "daemonScheduler";
+
+    /**
+     * Enqueue a daemon for execution in the immediate future
+     * 
+     * @param entry
+     *            the daemon entry
+     * @return <code>true</code> if the daemon was successfully queued,
+     *         <code>false</code> otherwise, for instance if the underlying
+     *         queue is over capacity
+     */
+    boolean enqueue( DaemonEntry entry );
+
+    /**
+     * Schedule a daemon execution.
+     * 
+     * @see DaemonEntry#getInterval()
+     * @param entry
+     *            the daemon entry
+     * @param nInitialDelay
+     *            the initial delay before the first execution
+     * @param unit
+     *            the unit of <code>nInitialDelay</code> argument
+     */
+    void schedule( DaemonEntry entry, long nInitialDelay, TimeUnit unit );
+
+    /**
+     * Unschedule a daemon
+     * 
+     * @param entry
+     *            the daemon entry
+     */
+    void unSchedule( DaemonEntry daemonEntry );
+
+    /**
+     * Perform an orderly shutdown, stopping daemon execution
+     */
+    void shutdown( );
+
+}

--- a/src/java/fr/paris/lutece/portal/service/daemon/IDaemonScheduler.java
+++ b/src/java/fr/paris/lutece/portal/service/daemon/IDaemonScheduler.java
@@ -50,11 +50,15 @@ public interface IDaemonScheduler
      * 
      * @param entry
      *            the daemon entry
+     * @param unit
+     *            the delay before execution
+     * @param nDelay
+     *            the unit of <code>nDelay</code> argument
      * @return <code>true</code> if the daemon was successfully queued,
      *         <code>false</code> otherwise, for instance if the underlying
      *         queue is over capacity
      */
-    boolean enqueue( DaemonEntry entry );
+    boolean enqueue( DaemonEntry entry, long nDelay, TimeUnit unit );
 
     /**
      * Schedule a daemon execution.

--- a/src/java/fr/paris/lutece/portal/service/mail/MailService.java
+++ b/src/java/fr/paris/lutece/portal/service/mail/MailService.java
@@ -60,6 +60,16 @@ public final class MailService
     }
 
     /**
+     * Enqueues a mail item to be sent
+     * @param item the mail item to enqueue
+     */
+    private static void enqueue( MailItem item )
+    {
+        getQueue( ).send( item );
+        AppDaemonService.signalDaemon( MailSenderDaemon.DAEMON_ID );
+    }
+
+    /**
      * Send a message asynchronously. The message is queued until a daemon thread send all awaiting messages
      * 
      * @param strRecipient
@@ -157,8 +167,7 @@ public final class MailService
         item.setFormat( MailItem.FORMAT_HTML );
         item.setUniqueRecipientTo( bUniqueRecipientTo );
 
-        IMailQueue queue = (IMailQueue) SpringContextService.getBean( BEAN_MAIL_QUEUE );
-        queue.send( item );
+        enqueue( item );
     }
 
     /**
@@ -256,8 +265,7 @@ public final class MailService
         item.setFilesAttachement( filesAttachement );
         item.setUniqueRecipientTo( bUniqueRecipientTo );
 
-        IMailQueue queue = (IMailQueue) SpringContextService.getBean( BEAN_MAIL_QUEUE );
-        queue.send( item );
+        enqueue( item );
     }
 
     /**
@@ -353,8 +361,7 @@ public final class MailService
         item.setFormat( MailItem.FORMAT_CALENDAR );
         item.setUniqueRecipientTo( bUniqueRecipientTo );
 
-        IMailQueue queue = (IMailQueue) SpringContextService.getBean( BEAN_MAIL_QUEUE );
-        queue.send( item );
+        enqueue( item );
     }
 
     /**
@@ -434,8 +441,7 @@ public final class MailService
         item.setFormat( MailItem.FORMAT_TEXT );
         item.setUniqueRecipientTo( bUniqueRecipientTo );
 
-        IMailQueue queue = (IMailQueue) SpringContextService.getBean( BEAN_MAIL_QUEUE );
-        queue.send( item );
+        enqueue( item );
     }
 
     /**
@@ -524,8 +530,7 @@ public final class MailService
         item.setFilesAttachement( filesAttachement );
         item.setUniqueRecipientTo( bUniqueRecipientTo );
 
-        IMailQueue queue = (IMailQueue) SpringContextService.getBean( BEAN_MAIL_QUEUE );
-        queue.send( item );
+        enqueue( item );
     }
 
     /**
@@ -534,7 +539,7 @@ public final class MailService
     public static void shutdown( )
     {
         // if there is mails that have not been sent call the daemon to flush the list
-        Daemon daemon = AppDaemonService.getDaemon( "mailSender" );
+        Daemon daemon = AppDaemonService.getDaemon( MailSenderDaemon.DAEMON_ID );
 
         if ( daemon != null )
         {

--- a/src/java/fr/paris/lutece/portal/web/system/DaemonsJspBean.java
+++ b/src/java/fr/paris/lutece/portal/web/system/DaemonsJspBean.java
@@ -38,6 +38,7 @@ import fr.paris.lutece.portal.service.i18n.I18nService;
 import fr.paris.lutece.portal.service.message.AdminMessage;
 import fr.paris.lutece.portal.service.message.AdminMessageService;
 import fr.paris.lutece.portal.service.template.AppTemplateService;
+import fr.paris.lutece.portal.service.util.AppLogService;
 import fr.paris.lutece.portal.web.admin.AdminPageJspBean;
 import fr.paris.lutece.util.html.HtmlTemplate;
 
@@ -61,6 +62,7 @@ public class DaemonsJspBean extends AdminPageJspBean
     private static final String PARAMETER_INTERVAL = "interval";
     private static final String ACTION_START = "START";
     private static final String ACTION_STOP = "STOP";
+    private static final String ACTION_RUN = "RUN";
     private static final String ACTION_UPDATE_INTERVAL = "UPDATE_INTERVAL";
     private static final String PROPERTY_FIELD_INTERVAL = "portal.system.manage_daemons.columnTitleInterval";
     private static final String MESSAGE_MANDATORY_FIELD = "portal.util.message.mandatoryField";
@@ -95,43 +97,45 @@ public class DaemonsJspBean extends AdminPageJspBean
         String strAction = request.getParameter( PARAMETER_ACTION );
         String strDaemonKey = request.getParameter( PARAMETER_DAEMON );
 
-        if ( strAction.equalsIgnoreCase( ACTION_START ) )
+        switch ( strAction )
         {
+        case ACTION_START:
             AppDaemonService.startDaemon( strDaemonKey );
-        }
-        else
-            if ( strAction.equalsIgnoreCase( ACTION_STOP ) )
+            break;
+        case ACTION_STOP:
+            AppDaemonService.stopDaemon( strDaemonKey );
+            break;
+        case ACTION_RUN:
+            AppDaemonService.signalDaemon( strDaemonKey );
+            break;
+        case ACTION_UPDATE_INTERVAL:
+            String strErrorMessage = null;
+            String strDaemonInterval = request.getParameter( PARAMETER_INTERVAL );
+
+            Object [ ] tabFieldInterval = {
+                I18nService.getLocalizedString( PROPERTY_FIELD_INTERVAL, getLocale( ) )
+            };
+
+            if ( StringUtils.isEmpty( strDaemonInterval ) )
             {
-                AppDaemonService.stopDaemon( strDaemonKey );
+                strErrorMessage = MESSAGE_MANDATORY_FIELD;
+            }
+            else
+                if ( !StringUtils.isNumeric( strDaemonInterval ) )
+                {
+                    strErrorMessage = MESSAGE_NUMERIC_FIELD;
+                }
+
+            if ( strErrorMessage != null )
+            {
+                return AdminMessageService.getMessageUrl( request, strErrorMessage, tabFieldInterval, AdminMessage.TYPE_STOP );
             }
 
-            else
-                if ( strAction.equalsIgnoreCase( ACTION_UPDATE_INTERVAL ) )
-                {
-                    String strErrorMessage = null;
-                    String strDaemonInterval = request.getParameter( PARAMETER_INTERVAL );
-
-                    Object [ ] tabFieldInterval = {
-                        I18nService.getLocalizedString( PROPERTY_FIELD_INTERVAL, getLocale( ) )
-                    };
-
-                    if ( StringUtils.isEmpty( strDaemonInterval ) )
-                    {
-                        strErrorMessage = MESSAGE_MANDATORY_FIELD;
-                    }
-                    else
-                        if ( !StringUtils.isNumeric( strDaemonInterval ) )
-                        {
-                            strErrorMessage = MESSAGE_NUMERIC_FIELD;
-                        }
-
-                    if ( strErrorMessage != null )
-                    {
-                        return AdminMessageService.getMessageUrl( request, strErrorMessage, tabFieldInterval, AdminMessage.TYPE_STOP );
-                    }
-
-                    AppDaemonService.modifyDaemonInterval( strDaemonKey, strDaemonInterval );
-                }
+            AppDaemonService.modifyDaemonInterval( strDaemonKey, strDaemonInterval );
+            break;
+        default:
+            AppLogService.error( "Unknown daemon action : " + strAction );
+        }
 
         return getHomeUrl( request );
     }

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/DaemonSchedulerTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/DaemonSchedulerTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -53,72 +52,6 @@ public class DaemonSchedulerTest extends LuteceTestCase
         {
             return true;
         }
-    }
-
-    public static final class TestDaemon extends Daemon
-    {
-        CyclicBarrier startBarrier = new CyclicBarrier( 2 );
-        CyclicBarrier completionBarrier = new CyclicBarrier( 2 );
-        boolean hasRun;
-        boolean shouldThrow;
-
-        public void setRunThrows( boolean shouldThrow )
-        {
-            this.shouldThrow = shouldThrow;
-        }
-
-        @Override
-        public void run( )
-        {
-            try
-            {
-                hasRun = false;
-                startBarrier.await( 10, TimeUnit.SECONDS );
-                hasRun = true;
-                completionBarrier.await( 10, TimeUnit.SECONDS );
-            }
-            catch ( InterruptedException | BrokenBarrierException | TimeoutException e )
-            {
-                e.printStackTrace( );
-            }
-            if ( shouldThrow )
-            {
-                throw new RuntimeException( "I'm a bad daemon" );
-            }
-        }
-
-        public boolean hasRun( )
-        {
-            return hasRun;
-        }
-
-        public void resetGo( )
-        {
-            startBarrier.reset( );
-        }
-
-        public void go( ) throws InterruptedException, BrokenBarrierException, TimeoutException
-        {
-            this.go( 10, TimeUnit.SECONDS );
-        }
-
-        public void go( long timeout, TimeUnit unit )
-                throws InterruptedException, BrokenBarrierException, TimeoutException
-        {
-            startBarrier.await( timeout, unit );
-        }
-
-        public void waitForCompletion( ) throws InterruptedException, BrokenBarrierException, TimeoutException
-        {
-            this.waitForCompletion( 10, TimeUnit.SECONDS );
-        }
-
-        public void waitForCompletion( long timeout, TimeUnit unit )
-                throws InterruptedException, BrokenBarrierException, TimeoutException
-        {
-            completionBarrier.await( timeout, unit );
-        }
-
     }
 
     public void testEnqueue( ) throws ClassNotFoundException, InstantiationException, IllegalAccessException,

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/DaemonSchedulerTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/DaemonSchedulerTest.java
@@ -1,0 +1,492 @@
+package fr.paris.lutece.portal.service.daemon;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class DaemonSchedulerTest extends LuteceTestCase
+{
+    private static final class ImmediateExecutorService extends AbstractExecutorService
+    {
+        @Override
+        public void execute( Runnable command )
+        {
+            command.run( );
+        }
+
+        @Override
+        public List<Runnable> shutdownNow( )
+        {
+            return null;
+        }
+
+        @Override
+        public void shutdown( )
+        {
+        }
+
+        @Override
+        public boolean isTerminated( )
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isShutdown( )
+        {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination( long timeout, TimeUnit unit ) throws InterruptedException
+        {
+            return true;
+        }
+    }
+
+    public static final class TestDaemon extends Daemon
+    {
+        CyclicBarrier startBarrier = new CyclicBarrier( 2 );
+        CyclicBarrier completionBarrier = new CyclicBarrier( 2 );
+        boolean hasRun;
+        boolean shouldThrow;
+
+        public void setRunThrows( boolean shouldThrow )
+        {
+            this.shouldThrow = shouldThrow;
+        }
+
+        @Override
+        public void run( )
+        {
+            try
+            {
+                hasRun = false;
+                startBarrier.await( 10, TimeUnit.SECONDS );
+                hasRun = true;
+                completionBarrier.await( 10, TimeUnit.SECONDS );
+            }
+            catch ( InterruptedException | BrokenBarrierException | TimeoutException e )
+            {
+                e.printStackTrace( );
+            }
+            if ( shouldThrow )
+            {
+                throw new RuntimeException( "I'm a bad daemon" );
+            }
+        }
+
+        public boolean hasRun( )
+        {
+            return hasRun;
+        }
+
+        public void resetGo( )
+        {
+            startBarrier.reset( );
+        }
+
+        public void go( ) throws InterruptedException, BrokenBarrierException, TimeoutException
+        {
+            this.go( 10, TimeUnit.SECONDS );
+        }
+
+        public void go( long timeout, TimeUnit unit )
+                throws InterruptedException, BrokenBarrierException, TimeoutException
+        {
+            startBarrier.await( timeout, unit );
+        }
+
+        public void waitForCompletion( ) throws InterruptedException, BrokenBarrierException, TimeoutException
+        {
+            this.waitForCompletion( 10, TimeUnit.SECONDS );
+        }
+
+        public void waitForCompletion( long timeout, TimeUnit unit )
+                throws InterruptedException, BrokenBarrierException, TimeoutException
+        {
+            completionBarrier.await( timeout, unit );
+        }
+
+    }
+
+    public void testEnqueue( ) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testEnqueue( false );
+    }
+
+    public void testEnqueueDaemonThrows( ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testEnqueue( true );
+    }
+
+    private void testEnqueue( boolean shouldThrow ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        BlockingQueue<DaemonEntry> queue = new LinkedBlockingQueue<>( );
+        ExecutorService executor = Executors.newSingleThreadExecutor( );
+        DaemonScheduler scheduler = new DaemonScheduler( queue, executor );
+        try
+        {
+            DaemonEntry entry = getDaemonEntry( "JUNIT" );
+            TestDaemon testDaemon = ( TestDaemon ) entry.getDaemon( );
+            testDaemon.setRunThrows( shouldThrow );
+            scheduler.enqueue( entry );
+            assertFalse( testDaemon.hasRun( ) );
+            testDaemon.go( );
+            testDaemon.waitForCompletion( );
+            assertTrue( testDaemon.hasRun( ) );
+        }
+        finally
+        {
+            scheduler.shutdown( );
+        }
+    }
+
+    private DaemonEntry getDaemonEntry( String name )
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException
+    {
+        DaemonEntry entry = new DaemonEntry( );
+        entry.setId( name );
+        entry.setIsRunning( true );
+        entry.setPluginName( "core" );
+        entry.setClassName( TestDaemon.class.getName( ) );
+        entry.loadDaemon( );
+        entry.setInterval( 1 );
+        TestDaemon testDaemon = ( TestDaemon ) entry.getDaemon( );
+        testDaemon.setPluginName( "core" );
+        return entry;
+    }
+
+    public void testEnqueueFull( ) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testEnqueueFull( false );
+    }
+
+    public void testEnqueueFullDaemonThrows( ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testEnqueueFull( true );
+    }
+
+    private void testEnqueueFull( boolean shouldThrow ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        BlockingQueue<DaemonEntry> queue = new LinkedBlockingQueue<>( 1 );
+        ExecutorService executor = new ImmediateExecutorService( );
+        DaemonScheduler scheduler = new DaemonScheduler( queue, executor );
+        try
+        {
+            DaemonEntry executing = getDaemonEntry( "JUNIT-executing" );
+            TestDaemon executingDaemon = ( TestDaemon ) executing.getDaemon( );
+            executingDaemon.setRunThrows( shouldThrow );
+            assertTrue( scheduler.enqueue( executing ) );
+            executingDaemon.go( );
+            DaemonEntry inqueue = getDaemonEntry( "JUNIT-inqueue" );
+            TestDaemon inqueueDaemon = ( TestDaemon ) inqueue.getDaemon( );
+            inqueueDaemon.setRunThrows( shouldThrow );
+            assertTrue( scheduler.enqueue( inqueue ) );
+            DaemonEntry refused = getDaemonEntry( "JUNIT-refused" );
+            assertFalse( scheduler.enqueue( refused ) );
+            executingDaemon.waitForCompletion( );
+            inqueueDaemon.go( );
+            inqueueDaemon.waitForCompletion( );
+        }
+        finally
+        {
+            scheduler.shutdown( );
+        }
+    }
+
+    public void testSchedule( ) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testSchedule( false );
+    }
+
+    public void testSchedulDaemonThrows( ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testSchedule( true );
+    }
+
+    private void testSchedule( boolean shouldThrow ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        BlockingQueue<DaemonEntry> queue = new LinkedBlockingQueue<>( );
+        ExecutorService executor = Executors.newSingleThreadExecutor( );
+        DaemonScheduler scheduler = new DaemonScheduler( queue, executor );
+        try
+        {
+            DaemonEntry entry = getDaemonEntry( "JUNIT" );
+            TestDaemon testDaemon = ( TestDaemon ) entry.getDaemon( );
+            testDaemon.setRunThrows( shouldThrow );
+            Instant start = Instant.now( );
+            scheduler.schedule( entry, 0L, TimeUnit.MILLISECONDS );
+            assertFalse( testDaemon.hasRun( ) );
+            testDaemon.go( );
+            System.out
+                    .println( "Daemon took " + Duration.between( start, Instant.now( ) ).toNanos( ) + "ns to execute" );
+            testDaemon.waitForCompletion( );
+            assertTrue( testDaemon.hasRun( ) );
+            testDaemon.go( );
+            assertTrue( 1000L <= Duration.between( start, Instant.now( ) ).toMillis( ) );
+            testDaemon.waitForCompletion( );
+            assertTrue( testDaemon.hasRun( ) );
+        }
+        finally
+        {
+            scheduler.shutdown( );
+        }
+    }
+
+    public void testScheduleDelay( ) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testScheduleDelay( false );
+    }
+
+    public void testScheduleDelayDaemonThrows( ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testScheduleDelay( true );
+    }
+
+    private void testScheduleDelay( boolean shouldThrow ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        BlockingQueue<DaemonEntry> queue = new LinkedBlockingQueue<>( );
+        ExecutorService executor = Executors.newSingleThreadExecutor( );
+        DaemonScheduler scheduler = new DaemonScheduler( queue, executor );
+        try
+        {
+            DaemonEntry entry = getDaemonEntry( "JUNIT" );
+            TestDaemon testDaemon = ( TestDaemon ) entry.getDaemon( );
+            testDaemon.setRunThrows( shouldThrow );
+            Instant start = Instant.now( );
+            scheduler.schedule( entry, 500L, TimeUnit.MILLISECONDS );
+            assertFalse( testDaemon.hasRun( ) );
+            testDaemon.go( );
+            assertTrue( 500L <= Duration.between( start, Instant.now( ) ).toMillis( ) );
+            testDaemon.waitForCompletion( );
+            assertTrue( testDaemon.hasRun( ) );
+        }
+        finally
+        {
+            scheduler.shutdown( );
+        }
+    }
+
+    public void testScheduleTwice( ) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testScheduleTwice( false );
+    }
+
+    public void testScheduleTwiceDaemonThrows( ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testScheduleTwice( true );
+    }
+
+    private void testScheduleTwice( boolean shouldThrow ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        BlockingQueue<DaemonEntry> queue = new LinkedBlockingQueue<>( );
+        ExecutorService executor = Executors.newSingleThreadExecutor( );
+        DaemonScheduler scheduler = new DaemonScheduler( queue, executor );
+        try
+        {
+            DaemonEntry entry = getDaemonEntry( "JUNIT" );
+            TestDaemon testDaemon = ( TestDaemon ) entry.getDaemon( );
+            testDaemon.setRunThrows( shouldThrow );
+            Instant start = Instant.now( );
+            scheduler.schedule( entry, 0L, TimeUnit.MICROSECONDS );
+            scheduler.schedule( entry, 500L, TimeUnit.MILLISECONDS );
+            assertFalse( testDaemon.hasRun( ) );
+            testDaemon.go( );
+            testDaemon.waitForCompletion( );
+            assertTrue( testDaemon.hasRun( ) );
+            testDaemon.go( );
+            long timeForSecondRun = Duration.between( start, Instant.now( ) ).toMillis( );
+            assertTrue( "Second run was " + timeForSecondRun + "ms after start", 1000L <= timeForSecondRun );
+            testDaemon.waitForCompletion( );
+            assertTrue( testDaemon.hasRun( ) );
+        }
+        finally
+        {
+            scheduler.shutdown( );
+        }
+    }
+
+    public void testUnScheduleNotScheduled( )
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException
+    {
+        BlockingQueue<DaemonEntry> queue = new LinkedBlockingQueue<>( );
+        ExecutorService executor = Executors.newSingleThreadExecutor( );
+        DaemonScheduler scheduler = new DaemonScheduler( queue, executor );
+        try
+        {
+            DaemonEntry entry = getDaemonEntry( "JUNIT" );
+            scheduler.unSchedule( entry );
+            // not sure how to assert something here
+        }
+        finally
+        {
+            scheduler.shutdown( );
+        }
+    }
+
+    public void testUnSchedule( ) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testUnSchedule( false );
+    }
+
+    public void testUnScheduleDaemonThrows( ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testUnSchedule( true );
+    }
+
+    private void testUnSchedule( boolean shouldThrow ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        BlockingQueue<DaemonEntry> queue = new LinkedBlockingQueue<>( );
+        ExecutorService executor = Executors.newSingleThreadExecutor( );
+        DaemonScheduler scheduler = new DaemonScheduler( queue, executor );
+        try
+        {
+            DaemonEntry entry = getDaemonEntry( "JUNIT" );
+            TestDaemon testDaemon = ( TestDaemon ) entry.getDaemon( );
+            testDaemon.setRunThrows( shouldThrow );
+            scheduler.schedule( entry, 0L, TimeUnit.MILLISECONDS );
+            assertFalse( testDaemon.hasRun( ) );
+            testDaemon.go( );
+            testDaemon.waitForCompletion( );
+            assertTrue( testDaemon.hasRun( ) );
+            scheduler.unSchedule( entry );
+            try
+            {
+                testDaemon.go( 1100L, TimeUnit.MILLISECONDS );
+                fail( "Daemon executed after unscheduling" );
+            }
+            catch ( TimeoutException e )
+            {
+                // OK
+            }
+        }
+        finally
+        {
+            scheduler.shutdown( );
+        }
+    }
+
+    public void testEnqueueWhileRunning( ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testEnqueueWhileRunning( false );
+    }
+
+    public void testEnqueueWhileRunningDaemonThrows( ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testEnqueueWhileRunning( true );
+    }
+
+    private void testEnqueueWhileRunning( boolean shouldThrow ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        BlockingQueue<DaemonEntry> queue = new LinkedBlockingQueue<>( );
+        ExecutorService executor = Executors.newCachedThreadPool( );
+        DaemonScheduler scheduler = new DaemonScheduler( queue, executor );
+        try
+        {
+            DaemonEntry executing = getDaemonEntry( "JUNIT-executing" );
+            TestDaemon executingDaemon = ( TestDaemon ) executing.getDaemon( );
+            executingDaemon.setRunThrows( shouldThrow );
+            assertTrue( scheduler.enqueue( executing ) );
+            executingDaemon.go( );
+            assertTrue( scheduler.enqueue( executing ) );
+            try
+            {
+                executingDaemon.go( 200, TimeUnit.MILLISECONDS );
+                fail( "Daemon started execution while already running" );
+            }
+            catch ( TimeoutException e )
+            {
+                executingDaemon.resetGo( );
+            }
+            executingDaemon.waitForCompletion( );
+            executingDaemon.go( );
+            executingDaemon.waitForCompletion( );
+        }
+        finally
+        {
+            scheduler.shutdown( );
+        }
+    }
+
+    public void testEnqueueCoalesce( ) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testEnqueueCoalesce( false );
+    }
+
+    public void testEnqueueCoalesceDaemonThrows( ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        testEnqueueCoalesce( true );
+    }
+
+    private void testEnqueueCoalesce( boolean shouldThrow ) throws ClassNotFoundException, InstantiationException,
+            IllegalAccessException, InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        BlockingQueue<DaemonEntry> queue = new LinkedBlockingQueue<>( );
+        ExecutorService executor = new ImmediateExecutorService( );
+        DaemonScheduler scheduler = new DaemonScheduler( queue, executor );
+        try
+        {
+            DaemonEntry executing = getDaemonEntry( "JUNIT-executing" );
+            TestDaemon executingDaemon = ( TestDaemon ) executing.getDaemon( );
+            executingDaemon.setRunThrows( shouldThrow );
+            assertTrue( scheduler.enqueue( executing ) );
+            executingDaemon.go( );
+            DaemonEntry inqueue = getDaemonEntry( "JUNIT-inqueue" );
+            TestDaemon inqueueDaemon = ( TestDaemon ) inqueue.getDaemon( );
+            inqueueDaemon.setRunThrows( shouldThrow );
+            assertTrue( scheduler.enqueue( inqueue ) );
+            assertTrue( scheduler.enqueue( inqueue ) );
+            executingDaemon.waitForCompletion( );
+            inqueueDaemon.go( );
+            inqueueDaemon.waitForCompletion( );
+            try
+            {
+                inqueueDaemon.go( 200, TimeUnit.MILLISECONDS );
+                fail( "Daemon started twice but should have been coalesced" );
+            }
+            catch ( TimeoutException e )
+            {
+
+            }
+        }
+        finally
+        {
+            scheduler.shutdown( );
+        }
+    }
+}

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/TestDaemon.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/TestDaemon.java
@@ -1,0 +1,72 @@
+package fr.paris.lutece.portal.service.daemon;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public final class TestDaemon extends Daemon
+{
+    CyclicBarrier startBarrier = new CyclicBarrier( 2 );
+    CyclicBarrier completionBarrier = new CyclicBarrier( 2 );
+    boolean hasRun;
+    boolean shouldThrow;
+
+    public void setRunThrows( boolean shouldThrow )
+    {
+        this.shouldThrow = shouldThrow;
+    }
+
+    @Override
+    public void run( )
+    {
+        try
+        {
+            hasRun = false;
+            startBarrier.await( 10, TimeUnit.SECONDS );
+            hasRun = true;
+            completionBarrier.await( 10, TimeUnit.SECONDS );
+        }
+        catch ( InterruptedException | BrokenBarrierException | TimeoutException e )
+        {
+            e.printStackTrace( );
+        }
+        if ( shouldThrow )
+        {
+            throw new RuntimeException( "I'm a bad daemon" );
+        }
+    }
+
+    public boolean hasRun( )
+    {
+        return hasRun;
+    }
+
+    public void resetGo( )
+    {
+        startBarrier.reset( );
+    }
+
+    public void go( ) throws InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        this.go( 10, TimeUnit.SECONDS );
+    }
+
+    public void go( long timeout, TimeUnit unit )
+            throws InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        startBarrier.await( timeout, unit );
+    }
+
+    public void waitForCompletion( ) throws InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        this.waitForCompletion( 10, TimeUnit.SECONDS );
+    }
+
+    public void waitForCompletion( long timeout, TimeUnit unit )
+            throws InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        completionBarrier.await( timeout, unit );
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
@@ -1,0 +1,32 @@
+package fr.paris.lutece.portal.service.daemon;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import fr.paris.lutece.portal.service.plugin.PluginService;
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class ThreadLauncherDaemonTest extends LuteceTestCase
+{
+    private boolean _runnableTimedOut;
+
+    public void testAddItemToQueue( ) throws InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        CyclicBarrier barrier = new CyclicBarrier( 2 );
+        _runnableTimedOut = false;
+        ThreadLauncherDaemon.addItemToQueue( ( ) -> {
+            try
+            {
+                barrier.await( 10L, TimeUnit.SECONDS );
+            }
+            catch ( InterruptedException | BrokenBarrierException | TimeoutException e )
+            {
+                _runnableTimedOut = true;
+            }
+        }, "key", PluginService.getCore( ) );
+        barrier.await( 250L, TimeUnit.MILLISECONDS );
+        assertFalse( _runnableTimedOut );
+    }
+}

--- a/src/test/java/fr/paris/lutece/portal/web/system/DaemonsJspBeanTest.java
+++ b/src/test/java/fr/paris/lutece/portal/web/system/DaemonsJspBeanTest.java
@@ -1,0 +1,161 @@
+package fr.paris.lutece.portal.web.system;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import fr.paris.lutece.portal.service.daemon.AppDaemonService;
+import fr.paris.lutece.portal.service.daemon.DaemonEntry;
+import fr.paris.lutece.portal.service.daemon.TestDaemon;
+import fr.paris.lutece.portal.service.util.AppPropertiesService;
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class DaemonsJspBeanTest extends LuteceTestCase
+{
+    private static final String JUNIT_DAEMON = "JUNIT";
+    private DaemonsJspBean bean;
+    private DaemonEntry _entry;
+    private String origMaxInitialStartDelay;
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        origMaxInitialStartDelay = setInitialStartDelay( );
+        bean = new DaemonsJspBean( );
+        _entry = new DaemonEntry( );
+        _entry.setId( JUNIT_DAEMON );
+        _entry.setClassName( TestDaemon.class.getName( ) );
+        _entry.setPluginName( "core" );
+        _entry.setInterval( 1 );
+        AppDaemonService.registerDaemon( _entry );
+    }
+
+    private String setInitialStartDelay( ) throws FileNotFoundException, IOException
+    {
+        File propertiesFile = new File( getResourcesDir( ) + "/WEB-INF/conf/daemons.properties" );
+        Properties props = new Properties( );
+        try ( FileInputStream is = new FileInputStream( propertiesFile ) )
+        {
+            props.load( is );
+        }
+        String orig = props.getProperty( "daemon.maxInitialStartDelay" );
+        props.setProperty( "daemon.maxInitialStartDelay", "1" );
+        try ( FileOutputStream out = new FileOutputStream( propertiesFile ) )
+        {
+            props.store( out, "junit" );
+        }
+        AppPropertiesService.reloadAll( );
+        return orig;
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        AppDaemonService.stopDaemon( JUNIT_DAEMON );
+        AppDaemonService.unregisterDaemon( JUNIT_DAEMON );
+        restoreInitialStartDelay( origMaxInitialStartDelay );
+        super.tearDown( );
+    }
+
+    private void restoreInitialStartDelay( String orig ) throws FileNotFoundException, IOException
+    {
+        File propertiesFile = new File( getResourcesDir( ) + "/WEB-INF/conf/daemons.properties" );
+        Properties props = new Properties( );
+        try ( FileInputStream is = new FileInputStream( propertiesFile ) )
+        {
+            props.load( is );
+        }
+        if ( orig == null )
+        {
+            props.remove( "daemon.maxInitialStartDelay" );
+        }
+        else
+        {
+            props.setProperty( "daemon.maxInitialStartDelay", orig );
+        }
+        try ( FileOutputStream out = new FileOutputStream( propertiesFile ) )
+        {
+            props.store( out, "junit" );
+        }
+        AppPropertiesService.reloadAll( );
+    }
+
+    public void testDoDaemonActionStart( ) throws InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        assertFalse( _entry.isRunning( ) );
+        MockHttpServletRequest request = new MockHttpServletRequest( );
+        request.setParameter( "action", "START" );
+        request.setParameter( "daemon", JUNIT_DAEMON );
+        bean.doDaemonAction( request );
+        assertTrue( _entry.isRunning( ) );
+        TestDaemon daemon = ( TestDaemon ) AppDaemonService.getDaemon( JUNIT_DAEMON );
+        daemon.go( 1500, TimeUnit.MILLISECONDS );
+        daemon.waitForCompletion( );
+    }
+
+    public void testDoDaemonActionStop( ) throws InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        assertFalse( _entry.isRunning( ) );
+        AppDaemonService.startDaemon( JUNIT_DAEMON );
+        TestDaemon daemon = ( TestDaemon ) AppDaemonService.getDaemon( JUNIT_DAEMON );
+        daemon.go( 1500, TimeUnit.MILLISECONDS );
+        daemon.waitForCompletion( );
+        MockHttpServletRequest request = new MockHttpServletRequest( );
+        request.setParameter( "action", "STOP" );
+        request.setParameter( "daemon", JUNIT_DAEMON );
+        bean.doDaemonAction( request );
+        assertFalse( _entry.isRunning( ) );
+        try
+        {
+            daemon.go( 1250, TimeUnit.MILLISECONDS );
+            fail( "Daemon still running after stop" );
+        }
+        catch ( TimeoutException e )
+        {
+            // ok
+        }
+    }
+
+    public void testDoDaemonActionRun( ) throws InterruptedException, BrokenBarrierException, TimeoutException
+    {
+        assertFalse( _entry.isRunning( ) );
+        _entry.setInterval( 1000 );
+        AppDaemonService.startDaemon( JUNIT_DAEMON );
+        TestDaemon daemon = ( TestDaemon ) AppDaemonService.getDaemon( JUNIT_DAEMON );
+        daemon.go( 1500, TimeUnit.MILLISECONDS );
+        daemon.waitForCompletion( );
+        MockHttpServletRequest request = new MockHttpServletRequest( );
+        request.setParameter( "action", "RUN" );
+        request.setParameter( "daemon", JUNIT_DAEMON );
+        bean.doDaemonAction( request );
+        daemon.go( 250, TimeUnit.MILLISECONDS );
+        daemon.waitForCompletion( );
+    }
+
+    public void testDoDaemonActionUpdateInterval( )
+    {
+        final long lTestInterval = 314159L;
+        MockHttpServletRequest request = new MockHttpServletRequest( );
+        request.setParameter( "action", "UPDATE_INTERVAL" );
+        request.setParameter( "daemon", JUNIT_DAEMON );
+        request.setParameter( "interval", Long.toString( lTestInterval ) );
+        bean.doDaemonAction( request );
+        assertEquals( lTestInterval, _entry.getInterval( ) );
+    }
+
+    public void testDoDaemonActionUnknown( )
+    {
+        MockHttpServletRequest request = new MockHttpServletRequest( );
+        request.setParameter( "action", "UNKNOWN" );
+        bean.doDaemonAction( request ); // does not throw
+    }
+}

--- a/webapp/WEB-INF/conf/config.properties
+++ b/webapp/WEB-INF/conf/config.properties
@@ -75,6 +75,9 @@ mail.charset=utf-8
 # mail daemon flow control : wait 'waitime' between each group of 'count' mail.
 mail.daemon.waittime=1
 mail.daemon.count=1000
+# mail daemon : how long to wait for in case of error before retrying (see java.util.concurrent.TimeUnit)
+mail.daemon.retryonerror.waittime=60
+mail.daemon.retryonerror.waittime.unit=SECONDS
 
 ################################################################################
 # Indexation (total->true or incremental->false)

--- a/webapp/WEB-INF/conf/core_context.xml
+++ b/webapp/WEB-INF/conf/core_context.xml
@@ -205,5 +205,22 @@
     <bean id="sitePropertiesGroup" class="fr.paris.lutece.portal.service.site.properties.DefaultSitePropertiesGroup" />
     
     <bean id="core.xpage.search" class="fr.paris.lutece.portal.web.search.SearchApp" scope="session" />
+    
+    <!-- Daemon management -->
+    <bean id="daemonQueue" class="java.util.concurrent.LinkedBlockingQueue"/>
+    <bean id="daemonExecutorQueue" class="java.util.concurrent.LinkedBlockingQueue"/>
+    <bean id="daemonThreadFactory" class="fr.paris.lutece.portal.service.daemon.DaemonThreadFactory"/>
+    <bean id="daemonExecutor" class="java.util.concurrent.ThreadPoolExecutor">
+    	<constructor-arg index="0" value="${daemon.ScheduledThreadCorePoolSize:30}"/> <!-- corePoolSize -->
+    	<constructor-arg index="1" value="${daemon.maximumPoolSize:30}"/> <!-- maximumPoolSize -->
+    	<constructor-arg index="2" value="${daemon.keepAliveTime:0}"/> <!-- keepAliveTime -->
+    	<constructor-arg index="3" value="${daemon.timeUnit:MILLISECONDS}"/> <!-- unit -->
+    	<constructor-arg index="4" ref="daemonExecutorQueue"/> <!-- workQueue -->
+    	<constructor-arg index="5" ref="daemonThreadFactory"/> <!-- threadFactory -->
+    </bean>
+    <bean id="daemonScheduler" class="fr.paris.lutece.portal.service.daemon.DaemonScheduler">
+    	<constructor-arg ref="daemonQueue"/>
+    	<constructor-arg ref="daemonExecutor"/>
+    </bean>
 
 </beans>

--- a/webapp/WEB-INF/conf/daemons.properties
+++ b/webapp/WEB-INF/conf/daemons.properties
@@ -11,8 +11,15 @@ daemon.maxAwaitTerminationDelay=15
 daemon.runThreadAsDaemon=0
 
 # Number of threads to keep in the pool even if they are idle
-daemon.ScheduledThreadCorePoolSize=5
-
+daemon.ScheduledThreadCorePoolSize=1
+# the maximum number of threads to allow in the pool
+daemon.maximumPoolSize=20
+# when the number of threads is greater than
+# the core, maximum time that excess idle threads
+# will wait for new tasks before terminating.
+daemon.keepAliveTime=0
+# the time unit for the daemon.keepAliveTime parameter (see java.util.concurrent.TimeUnit)
+daemon.timeUnit=MILLISECONDS
 
 
 ################################################################################

--- a/webapp/WEB-INF/conf/daemons.properties
+++ b/webapp/WEB-INF/conf/daemons.properties
@@ -39,6 +39,6 @@ daemon.anonymizationDaemon.onstartup=0
 daemon.accountLifeTimeDaemon.interval=86400
 daemon.accountLifeTimeDaemon.onstartup=1
 
-daemon.threadLauncherDaemon.interval=60
+daemon.threadLauncherDaemon.interval=86400
 daemon.threadLauncherDaemon.onstartup=1
 daemon.threadLauncherDaemon.maxNumberOfThread=10

--- a/webapp/WEB-INF/conf/daemons.properties
+++ b/webapp/WEB-INF/conf/daemons.properties
@@ -30,7 +30,7 @@ daemon.timeUnit=MILLISECONDS
 daemon.indexer.interval=300
 daemon.indexer.onstartup=1
 
-daemon.mailSender.interval=60
+daemon.mailSender.interval=86400
 daemon.mailSender.onstartup=1
 
 daemon.anonymizationDaemon.interval=86400

--- a/webapp/WEB-INF/templates/admin/system/config_properties.html
+++ b/webapp/WEB-INF/templates/admin/system/config_properties.html
@@ -75,6 +75,9 @@ mail.charset=utf-8
 # mail daemon flow control : wait 'waitime' between each group of 'count' mail.
 mail.daemon.waittime=1
 mail.daemon.count=1000
+# mail daemon : how long to wait for in case of error before retrying (see java.util.concurrent.TimeUnit)
+mail.daemon.retryonerror.waittime=60
+mail.daemon.retryonerror.waittime.unit=SECONDS
 
 ################################################################################
 # Indexation (total->true or incremental->false)

--- a/webapp/WEB-INF/templates/admin/system/manage_daemons.html
+++ b/webapp/WEB-INF/templates/admin/system/manage_daemons.html
@@ -85,6 +85,7 @@
 							<input type="hidden" name="daemon" value="${daemon.id}">
 							<#if daemon.running>
 								<@button type='submit' title='#i18n{portal.system.manage_daemons.buttonStop} ${daemon.id}' name='action' value='STOP' buttonIcon='stop' color='btn-danger' showTitle=false />
+								<@button type='submit' title='#i18n{portal.system.manage_daemons.buttonRun} ${daemon.id}' name='action' value='RUN' buttonIcon='play' color='btn-success' showTitle=false />
 							  <#else>
 								<@button type='submit' title='#i18n{portal.system.manage_daemons.buttonStart} ${daemon.id}' name='action' value='START' buttonIcon='play' color='btn-success' showTitle=false />
 							</#if>


### PR DESCRIPTION
Add a daemon scheduler interface and implementation.
The scheduler can schedule/unschedule daemon runs, as was possible before. Add the possibility to run a daemon on demand, possibly after a delay.
Demand run and scheduled run rely on the same underlying mechanism.

Add a button to run a daemon immediately on the manage daemons page

Turn the MailSenderDaemon into a reactive one.  Enqueuing a mail signals the daemon.
Use the daemon signaling system for error recovery or rate limiting

Make the threadLauncherDaemon reactive.
Have the daemon signaled when the runnable ends.
This allows dead threads reclaiming, and execution of delayed runnable
which where blocked from execution because no slot was available for their
key.