### PR TITLE
LUTECE-2087 : Add a token depending on content to css and js links from LinksInclude

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/util/CryptoService.java
+++ b/src/java/fr/paris/lutece/portal/service/util/CryptoService.java
@@ -33,6 +33,8 @@
  */
 package fr.paris.lutece.portal.service.util;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
@@ -96,6 +98,47 @@ public final class CryptoService
         }
 
         return hash;
+    }
+
+    /**
+     * Get a digest of the content of a stream
+     * 
+     * @param stream
+     *            the stream containing the data to digest
+     * @param strAlgorithm
+     *            the digest Algorithm
+     * @return hex encoded digest string
+     * @see MessageDigest
+     * @since 6.0.0
+     */
+    public static String digest( InputStream stream, String strAlgorithm )
+    {
+        MessageDigest digest;
+        try
+        {
+            digest = MessageDigest.getInstance( strAlgorithm );
+        }
+        catch ( NoSuchAlgorithmException e )
+        {
+            AppLogService.error( strAlgorithm + " not found", e );
+            return null;
+        }
+        byte[ ] buffer = new byte[ 1024 ];
+        try
+        {
+            int nNumBytesRead = stream.read( buffer );
+            while ( nNumBytesRead != -1 )
+            {
+                digest.update( buffer, 0, nNumBytesRead );
+                nNumBytesRead = stream.read( buffer );
+            }
+        }
+        catch ( IOException e )
+        {
+            AppLogService.error( "Error reading stream", e );
+            return null;
+        }
+        return byteToHex( digest.digest( ) );
     }
 
     /**

--- a/src/java/fr/paris/lutece/portal/web/includes/LinksIncludeCacheService.java
+++ b/src/java/fr/paris/lutece/portal/web/includes/LinksIncludeCacheService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2017, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.web.includes;
+
+import java.util.Locale;
+
+import fr.paris.lutece.portal.service.cache.AbstractCacheableService;
+import fr.paris.lutece.portal.service.plugin.PluginEvent;
+import fr.paris.lutece.portal.service.plugin.PluginEventListener;
+import fr.paris.lutece.portal.service.plugin.PluginService;
+
+/**
+ * Cache service for LinksInclude
+ */
+public class LinksIncludeCacheService extends AbstractCacheableService implements PluginEventListener
+{
+    public static final String SERVICE_NAME = "LinksIncludeCacheService";
+
+    public LinksIncludeCacheService( )
+    {
+        initCache( );
+        PluginService.registerPluginEventListener( this );
+    }
+
+    @Override
+    public String getName( )
+    {
+        return SERVICE_NAME;
+    }
+
+    /**
+     * Get a cache key
+     * @param nMode mode
+     * @param strPage page id
+     * @param locale locale
+     * @return a cache key
+     */
+    public String getCacheKey( int nMode, String strPage, Locale locale )
+    {
+        StringBuilder builder = new StringBuilder( "[mode=" );
+        builder.append( nMode ).append( ']' );
+        if ( strPage != null )
+        {
+            builder.append( "[page=" ).append( strPage ).append( ']' );
+        }
+        builder.append( "[locale=" ).append( locale ).append( ']' );
+        return builder.toString( );
+    }
+
+    @Override
+    public void processPluginEvent( PluginEvent event )
+    {
+        resetCache( );
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeCacheServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeCacheServiceTest.java
@@ -1,0 +1,70 @@
+package fr.paris.lutece.portal.web.includes;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import fr.paris.lutece.portal.service.plugin.Plugin;
+import fr.paris.lutece.portal.service.plugin.PluginEvent;
+import fr.paris.lutece.portal.service.plugin.PluginService;
+import fr.paris.lutece.portal.service.spring.SpringContextService;
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class LinksIncludeCacheServiceTest extends LuteceTestCase
+{
+    private LinksIncludeCacheService service;
+    private boolean bOrigCacheStatus;
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        service = SpringContextService.getBean( LinksIncludeCacheService.SERVICE_NAME );
+        bOrigCacheStatus = service.isCacheEnable( );
+        service.enableCache( true );
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        service.enableCache( bOrigCacheStatus );
+        super.tearDown( );
+    }
+
+    public void testGetCacheKey( )
+    {
+        Set<String> keys = new HashSet<>( );
+        for ( int nMode : new int[ ] { 0, 1 } )
+        {
+            for ( String strPage : new String[ ] { null, "test", "test2" } )
+            {
+                for ( Locale locale : new Locale[ ] { null, Locale.FRANCE, Locale.FRENCH } )
+                {
+                    String key = service.getCacheKey( nMode, strPage, locale );
+                    assertTrue( "key " + key + " was already generated", keys.add( key ) );
+                }
+            }
+        }
+    }
+
+    public void testProcessPluginEvent( )
+    {
+        service.putInCache( "key", "value" );
+        assertEquals( "value", service.getFromCache( "key" ) );
+        service.processPluginEvent( null );
+        assertNull( service.getFromCache( "key" ) );
+        for ( Plugin plugin : new Plugin[ ] { null, PluginService.getCore( ) } )
+        {
+            for ( int eventType : new int[ ] { PluginEvent.PLUGIN_INSTALLED, PluginEvent.PLUGIN_POOL_CHANGED,
+                    PluginEvent.PLUGIN_UNINSTALLED } )
+            {
+                service.putInCache( "key", "value" );
+                assertEquals( "value", service.getFromCache( "key" ) );
+                PluginEvent event = new PluginEvent( plugin, eventType );
+                service.processPluginEvent( event );
+                assertNull( service.getFromCache( "key" ) );
+            }
+        }
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTest.java
+++ b/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTest.java
@@ -1,0 +1,716 @@
+package fr.paris.lutece.portal.web.includes;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockServletContext;
+
+import fr.paris.lutece.portal.service.content.PageData;
+import fr.paris.lutece.portal.service.plugin.PluginService;
+import fr.paris.lutece.portal.service.util.AppPathService;
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class LinksIncludeTest extends LuteceTestCase
+{
+    private static final String PLUGIN_NAME = "linksIncludeTestPlugin";
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        File dirPlugin = new File( AppPathService.getPath( "path.plugins" ) );
+        File testPluginFile = new File( dirPlugin, PLUGIN_NAME + ".xml" );
+        try ( BufferedWriter writer = new BufferedWriter( new FileWriter( testPluginFile ) ) )
+        {
+            writer.write( "<plug-in><name>" + PLUGIN_NAME + "</name><class>" + LinksIncludeTestPlugin.class.getName( )
+                    + "</class>"
+                    + "<icon-url>../../images/admin/skin/plugins/myplugin/myplugin.gif</icon-url></plug-in>" );
+        }
+        PluginService.init( );
+        PluginService.getPlugin( PLUGIN_NAME ).install( );
+
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        PluginService.getPlugin( PLUGIN_NAME ).uninstall( );
+        File dirPlugin = new File( AppPathService.getPath( "path.plugins" ) );
+        File testPluginFile = new File( dirPlugin, PLUGIN_NAME + ".xml" );
+        testPluginFile.delete( );
+        PluginService.init( );
+        super.tearDown( );
+    }
+
+    public void testGetURICssAddPrefix( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> styleSheets = new ArrayList<>( );
+        styleSheets.add( PLUGIN_NAME + "/style.css" );
+        plugin.setCssStyleSheets( styleSheets );
+        plugin.setCssStyleSheetsScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_css_links" );
+        assertEquals(
+                "<link rel=\"stylesheet\"  href=\"css/plugins/linksIncludeTestPlugin/style.css\" type=\"text/css\"  media=\"screen\" />\n",
+                cssLinks );
+    }
+
+    public void testGetURICssAbsoluteHttp( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> styleSheets = new ArrayList<>( );
+        styleSheets.add( "http://example.com/style.css" );
+        plugin.setCssStyleSheets( styleSheets );
+        plugin.setCssStyleSheetsScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_css_links" );
+        assertEquals(
+                "<link rel=\"stylesheet\"  href=\"http://example.com/style.css\" type=\"text/css\"  media=\"screen\" />\n",
+                cssLinks );
+    }
+
+    public void testGetURICssAbsoluteHttps( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> styleSheets = new ArrayList<>( );
+        styleSheets.add( "https://example.com/style.css" );
+        plugin.setCssStyleSheets( styleSheets );
+        plugin.setCssStyleSheetsScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_css_links" );
+        assertEquals(
+                "<link rel=\"stylesheet\"  href=\"https://example.com/style.css\" type=\"text/css\"  media=\"screen\" />\n",
+                cssLinks );
+    }
+
+    public void testGetURICssProtocolRelative( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> styleSheets = new ArrayList<>( );
+        styleSheets.add( "//example.com/style.css" );
+        plugin.setCssStyleSheets( styleSheets );
+        plugin.setCssStyleSheetsScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_css_links" );
+        assertEquals(
+                "<link rel=\"stylesheet\"  href=\"//example.com/style.css\" type=\"text/css\"  media=\"screen\" />\n",
+                cssLinks );
+    }
+
+    public void testGetURICssHash( ) throws IOException
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> styleSheets = new ArrayList<>( );
+        styleSheets.add( "linksIncludeTestPlugin/junithashed.css" );
+        File hashedFile = new File( getResourcesDir( ), "css/plugins/linksIncludeTestPlugin/junithashed.css" );
+        System.out.println( hashedFile.toString( ) );
+        hashedFile.getParentFile( ).mkdirs( );
+        try ( FileWriter writer = new FileWriter( hashedFile ) )
+        {
+            writer.write( "abcd" );
+        }
+        try
+        {
+            plugin.setCssStyleSheets( styleSheets );
+            plugin.setCssStyleSheetsScopePortal( true );
+            LinksInclude include = new LinksInclude( );
+            Map<String, Object> rootModel = new HashMap<>( );
+            PageData data = new PageData( );
+            int nMode = 0;
+            ServletContext servletContext = new MockServletContext( )
+            {
+
+                @Override
+                public InputStream getResourceAsStream( String path )
+                {
+                    File file = new File( getResourcesDir( ), path );
+                    if ( file.exists( ) )
+                    {
+                        try
+                        {
+                            return new FileInputStream( file );
+                        }
+                        catch ( FileNotFoundException e )
+                        {
+                            return null;
+                        }
+                    }
+                    return null;
+                }
+
+            };
+            MockHttpServletRequest request = new MockHttpServletRequest( servletContext );
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks = ( String ) rootModel.get( "plugins_css_links" );
+            assertEquals(
+                    "<link rel=\"stylesheet\"  href=\"css/plugins/linksIncludeTestPlugin/junithashed.css?lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\" type=\"text/css\"  media=\"screen\" />\n",
+                    cssLinks );
+            try ( FileWriter writer = new FileWriter( hashedFile ) )
+            {
+                writer.write( "bbcd" );
+            }
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks2 = ( String ) rootModel.get( "plugins_css_links" );
+            assertNotNull( cssLinks2 );
+            assertFalse( cssLinks.equals( cssLinks2 ) );
+            assertEquals(
+                    "<link rel=\"stylesheet\"  href=\"css/plugins/linksIncludeTestPlugin/junithashed.css?lutece_h=531ba794ef006cd3d69cf1acb33ddeccf8d6c655fb08f469335f8c2c32e2ab68\" type=\"text/css\"  media=\"screen\" />\n",
+                    cssLinks2 );
+        }
+        finally
+        {
+            hashedFile.delete( );
+        }
+    }
+
+    public void testGetURICssHashQuery( ) throws IOException
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> styleSheets = new ArrayList<>( );
+        styleSheets.add( "linksIncludeTestPlugin/junithashed.css?arg=value" );
+        File hashedFile = new File( getResourcesDir( ), "css/plugins/linksIncludeTestPlugin/junithashed.css" );
+        System.out.println( hashedFile.toString( ) );
+        hashedFile.getParentFile( ).mkdirs( );
+        try ( FileWriter writer = new FileWriter( hashedFile ) )
+        {
+            writer.write( "abcd" );
+        }
+        try
+        {
+            plugin.setCssStyleSheets( styleSheets );
+            plugin.setCssStyleSheetsScopePortal( true );
+            LinksInclude include = new LinksInclude( );
+            Map<String, Object> rootModel = new HashMap<>( );
+            PageData data = new PageData( );
+            int nMode = 0;
+            ServletContext servletContext = new MockServletContext( )
+            {
+
+                @Override
+                public InputStream getResourceAsStream( String path )
+                {
+                    File file = new File( getResourcesDir( ), path );
+                    if ( file.exists( ) )
+                    {
+                        try
+                        {
+                            return new FileInputStream( file );
+                        }
+                        catch ( FileNotFoundException e )
+                        {
+                            return null;
+                        }
+                    }
+                    return null;
+                }
+
+            };
+            MockHttpServletRequest request = new MockHttpServletRequest( servletContext );
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks = ( String ) rootModel.get( "plugins_css_links" );
+            assertEquals(
+                    "<link rel=\"stylesheet\"  href=\"css/plugins/linksIncludeTestPlugin/junithashed.css?arg=value&lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\" type=\"text/css\"  media=\"screen\" />\n",
+                    cssLinks );
+        }
+        finally
+        {
+            hashedFile.delete( );
+        }
+    }
+
+    public void testGetURICssHashDigestError( ) throws IOException
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> styleSheets = new ArrayList<>( );
+        styleSheets.add( "linksIncludeTestPlugin/junithashed.css" );
+        File hashedFile = new File( getResourcesDir( ), "css/plugins/linksIncludeTestPlugin/junithashed.css" );
+        System.out.println( hashedFile.toString( ) );
+        hashedFile.getParentFile( ).mkdirs( );
+        try ( FileWriter writer = new FileWriter( hashedFile ) )
+        {
+            writer.write( "abcd" );
+        }
+        try
+        {
+            plugin.setCssStyleSheets( styleSheets );
+            plugin.setCssStyleSheetsScopePortal( true );
+            LinksInclude include = new LinksInclude( );
+            Map<String, Object> rootModel = new HashMap<>( );
+            PageData data = new PageData( );
+            int nMode = 0;
+            ServletContext servletContext = new MockServletContext( )
+            {
+
+                @Override
+                public InputStream getResourceAsStream( String path )
+                {
+                    File file = new File( getResourcesDir( ), path );
+                    if ( file.exists( ) )
+                    {
+                        return new InputStream( )
+                        {
+
+                            @Override
+                            public int read( ) throws IOException
+                            {
+                                throw new IOException( "Mocking IO error" );
+                            }
+                        };
+                    }
+                    return null;
+                }
+
+            };
+            MockHttpServletRequest request = new MockHttpServletRequest( servletContext );
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks = ( String ) rootModel.get( "plugins_css_links" );
+            assertEquals(
+                    "<link rel=\"stylesheet\"  href=\"css/plugins/linksIncludeTestPlugin/junithashed.css\" type=\"text/css\"  media=\"screen\" />\n",
+                    cssLinks );
+        }
+        finally
+        {
+            hashedFile.delete( );
+        }
+    }
+
+    public void testGetURICssHashStreamCloseError( ) throws IOException
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> styleSheets = new ArrayList<>( );
+        styleSheets.add( "linksIncludeTestPlugin/junithashed.css" );
+        File hashedFile = new File( getResourcesDir( ), "css/plugins/linksIncludeTestPlugin/junithashed.css" );
+        System.out.println( hashedFile.toString( ) );
+        hashedFile.getParentFile( ).mkdirs( );
+        try ( FileWriter writer = new FileWriter( hashedFile ) )
+        {
+            writer.write( "abcd" );
+        }
+        try
+        {
+            plugin.setCssStyleSheets( styleSheets );
+            plugin.setCssStyleSheetsScopePortal( true );
+            LinksInclude include = new LinksInclude( );
+            Map<String, Object> rootModel = new HashMap<>( );
+            PageData data = new PageData( );
+            int nMode = 0;
+            ServletContext servletContext = new MockServletContext( )
+            {
+
+                @Override
+                public InputStream getResourceAsStream( String path )
+                {
+                    File file = new File( getResourcesDir( ), path );
+                    if ( file.exists( ) )
+                    {
+                        try
+                        {
+                            return new FileInputStream( file )
+                            {
+
+                                @Override
+                                public void close( ) throws IOException
+                                {
+                                    throw new IOException( "Mocking IO error on close" );
+                                }
+
+                            };
+                        }
+                        catch ( FileNotFoundException e )
+                        {
+                            return null;
+                        }
+                    }
+                    return null;
+                }
+
+            };
+            MockHttpServletRequest request = new MockHttpServletRequest( servletContext );
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks = ( String ) rootModel.get( "plugins_css_links" );
+            assertEquals(
+                    "<link rel=\"stylesheet\"  href=\"css/plugins/linksIncludeTestPlugin/junithashed.css?lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\" type=\"text/css\"  media=\"screen\" />\n",
+                    cssLinks );
+        }
+        finally
+        {
+            hashedFile.delete( );
+        }
+    }
+
+    public void testGetURICssBadURI( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> styleSheets = new ArrayList<>( );
+        styleSheets.add( "://style.css" );
+        plugin.setCssStyleSheets( styleSheets );
+        plugin.setCssStyleSheetsScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_css_links" );
+        assertEquals( "", cssLinks );
+    }
+
+    // Javscript link
+
+    public void testGetURIJavascriptAddPrefix( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> javascripts = new ArrayList<>( );
+        javascripts.add( PLUGIN_NAME + "/script.js" );
+        plugin.setJavascriptFiles( javascripts );
+        plugin.setJavascriptFilesScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_javascript_links" );
+        assertEquals( "<script src=\"js/plugins/linksIncludeTestPlugin/script.js\" type=\"text/javascript\" ></script>",
+                cssLinks );
+    }
+
+    public void testGetURIJavascriptAbsoluteHttp( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> javascripts = new ArrayList<>( );
+        javascripts.add( "http://example.com/script.js" );
+        plugin.setJavascriptFiles( javascripts );
+        plugin.setJavascriptFilesScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_javascript_links" );
+        assertEquals( "<script src=\"http://example.com/script.js\" type=\"text/javascript\" ></script>", cssLinks );
+    }
+
+    public void testGetURIJavascriptAbsoluteHttps( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> javascripts = new ArrayList<>( );
+        javascripts.add( "https://example.com/script.js" );
+        plugin.setJavascriptFiles( javascripts );
+        plugin.setJavascriptFilesScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_javascript_links" );
+        assertEquals( "<script src=\"https://example.com/script.js\" type=\"text/javascript\" ></script>", cssLinks );
+    }
+
+    public void testGetURIJavascriptProtocolRelative( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> javascripts = new ArrayList<>( );
+        javascripts.add( "//example.com/script.js" );
+        plugin.setJavascriptFiles( javascripts );
+        plugin.setJavascriptFilesScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_javascript_links" );
+        assertEquals( "<script src=\"//example.com/script.js\" type=\"text/javascript\" ></script>", cssLinks );
+    }
+
+    public void testGetURIJavascriptHash( ) throws IOException
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> javascripts = new ArrayList<>( );
+        javascripts.add( "linksIncludeTestPlugin/scripthashed.js" );
+        File hashedFile = new File( getResourcesDir( ), "js/plugins/linksIncludeTestPlugin/scripthashed.js" );
+        hashedFile.getParentFile( ).mkdirs( );
+        try ( FileWriter writer = new FileWriter( hashedFile ) )
+        {
+            writer.write( "abcd" );
+        }
+        try
+        {
+            plugin.setJavascriptFiles( javascripts );
+            plugin.setJavascriptFilesScopePortal( true );
+            LinksInclude include = new LinksInclude( );
+            Map<String, Object> rootModel = new HashMap<>( );
+            PageData data = new PageData( );
+            int nMode = 0;
+            ServletContext servletContext = new MockServletContext( )
+            {
+
+                @Override
+                public InputStream getResourceAsStream( String path )
+                {
+                    File file = new File( getResourcesDir( ), path );
+                    if ( file.exists( ) )
+                    {
+                        try
+                        {
+                            return new FileInputStream( file );
+                        }
+                        catch ( FileNotFoundException e )
+                        {
+                            return null;
+                        }
+                    }
+                    return null;
+                }
+
+            };
+            MockHttpServletRequest request = new MockHttpServletRequest( servletContext );
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks = ( String ) rootModel.get( "plugins_javascript_links" );
+            assertEquals(
+                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\" type=\"text/javascript\" ></script>",
+                    cssLinks );
+            try ( FileWriter writer = new FileWriter( hashedFile ) )
+            {
+                writer.write( "bbcd" );
+            }
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks2 = ( String ) rootModel.get( "plugins_javascript_links" );
+            assertNotNull( cssLinks2 );
+            assertFalse( cssLinks.equals( cssLinks2 ) );
+            assertEquals(
+                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?lutece_h=531ba794ef006cd3d69cf1acb33ddeccf8d6c655fb08f469335f8c2c32e2ab68\" type=\"text/javascript\" ></script>",
+                    cssLinks2 );
+        }
+        finally
+        {
+            hashedFile.delete( );
+        }
+    }
+
+    public void testGetURIJavascriptHashQuery( ) throws IOException
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> javascripts = new ArrayList<>( );
+        javascripts.add( "linksIncludeTestPlugin/scripthashed.js?arg=value" );
+        File hashedFile = new File( getResourcesDir( ), "js/plugins/linksIncludeTestPlugin/scripthashed.js" );
+        hashedFile.getParentFile( ).mkdirs( );
+        try ( FileWriter writer = new FileWriter( hashedFile ) )
+        {
+            writer.write( "abcd" );
+        }
+        try
+        {
+            plugin.setJavascriptFiles( javascripts );
+            plugin.setJavascriptFilesScopePortal( true );
+            LinksInclude include = new LinksInclude( );
+            Map<String, Object> rootModel = new HashMap<>( );
+            PageData data = new PageData( );
+            int nMode = 0;
+            ServletContext servletContext = new MockServletContext( )
+            {
+
+                @Override
+                public InputStream getResourceAsStream( String path )
+                {
+                    File file = new File( getResourcesDir( ), path );
+                    if ( file.exists( ) )
+                    {
+                        try
+                        {
+                            return new FileInputStream( file );
+                        }
+                        catch ( FileNotFoundException e )
+                        {
+                            return null;
+                        }
+                    }
+                    return null;
+                }
+
+            };
+            MockHttpServletRequest request = new MockHttpServletRequest( servletContext );
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks = ( String ) rootModel.get( "plugins_javascript_links" );
+            assertEquals(
+                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?arg=value&lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\" type=\"text/javascript\" ></script>",
+                    cssLinks );
+        }
+        finally
+        {
+            hashedFile.delete( );
+        }
+    }
+
+    public void testGetURIJavascriptHashDigestError( ) throws IOException
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> javascripts = new ArrayList<>( );
+        javascripts.add( "linksIncludeTestPlugin/scripthashed.js" );
+        File hashedFile = new File( getResourcesDir( ), "js/plugins/linksIncludeTestPlugin/scripthashed.js" );
+        hashedFile.getParentFile( ).mkdirs( );
+        try ( FileWriter writer = new FileWriter( hashedFile ) )
+        {
+            writer.write( "abcd" );
+        }
+        try
+        {
+            plugin.setJavascriptFiles( javascripts );
+            plugin.setJavascriptFilesScopePortal( true );
+            LinksInclude include = new LinksInclude( );
+            Map<String, Object> rootModel = new HashMap<>( );
+            PageData data = new PageData( );
+            int nMode = 0;
+            ServletContext servletContext = new MockServletContext( )
+            {
+
+                @Override
+                public InputStream getResourceAsStream( String path )
+                {
+                    File file = new File( getResourcesDir( ), path );
+                    if ( file.exists( ) )
+                    {
+                        return new InputStream( )
+                        {
+
+                            @Override
+                            public int read( ) throws IOException
+                            {
+                                throw new IOException( "Mocking IO error" );
+                            }
+                        };
+                    }
+                    return null;
+                }
+
+            };
+            MockHttpServletRequest request = new MockHttpServletRequest( servletContext );
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks = ( String ) rootModel.get( "plugins_javascript_links" );
+            assertEquals(
+                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js\" type=\"text/javascript\" ></script>",
+                    cssLinks );
+        }
+        finally
+        {
+            hashedFile.delete( );
+        }
+    }
+
+    public void testGetURIJavascriptHashStreamCloseError( ) throws IOException
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> javascripts = new ArrayList<>( );
+        javascripts.add( "linksIncludeTestPlugin/scripthashed.js" );
+        File hashedFile = new File( getResourcesDir( ), "js/plugins/linksIncludeTestPlugin/scripthashed.js" );
+        hashedFile.getParentFile( ).mkdirs( );
+        try ( FileWriter writer = new FileWriter( hashedFile ) )
+        {
+            writer.write( "abcd" );
+        }
+        try
+        {
+            plugin.setJavascriptFiles( javascripts );
+            plugin.setJavascriptFilesScopePortal( true );
+            LinksInclude include = new LinksInclude( );
+            Map<String, Object> rootModel = new HashMap<>( );
+            PageData data = new PageData( );
+            int nMode = 0;
+            ServletContext servletContext = new MockServletContext( )
+            {
+
+                @Override
+                public InputStream getResourceAsStream( String path )
+                {
+                    File file = new File( getResourcesDir( ), path );
+                    if ( file.exists( ) )
+                    {
+                        try
+                        {
+                            return new FileInputStream( file )
+                            {
+
+                                @Override
+                                public void close( ) throws IOException
+                                {
+                                    throw new IOException( "Mocking IO error on close" );
+                                }
+
+                            };
+                        }
+                        catch ( FileNotFoundException e )
+                        {
+                            return null;
+                        }
+                    }
+                    return null;
+                }
+
+            };
+            MockHttpServletRequest request = new MockHttpServletRequest( servletContext );
+            include.fillTemplate( rootModel, data, nMode, request );
+            String cssLinks = ( String ) rootModel.get( "plugins_javascript_links" );
+            assertEquals(
+                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\" type=\"text/javascript\" ></script>",
+                    cssLinks );
+        }
+        finally
+        {
+            hashedFile.delete( );
+        }
+    }
+
+    public void testGetURIJavascriptBadURI( )
+    {
+        LinksIncludeTestPlugin plugin = ( LinksIncludeTestPlugin ) PluginService.getPlugin( PLUGIN_NAME );
+        List<String> javascripts = new ArrayList<>( );
+        javascripts.add( "://script.js" );
+        plugin.setJavascriptFiles( javascripts );
+        plugin.setJavascriptFilesScopePortal( true );
+        LinksInclude include = new LinksInclude( );
+        Map<String, Object> rootModel = new HashMap<>( );
+        PageData data = new PageData( );
+        int nMode = 0;
+        HttpServletRequest request = new MockHttpServletRequest( );
+        include.fillTemplate( rootModel, data, nMode, request );
+        String cssLinks = ( String ) rootModel.get( "plugins_javascript_links" );
+        assertEquals( "", cssLinks );
+    }
+}

--- a/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTestCacheDisabled.java
+++ b/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTestCacheDisabled.java
@@ -1,0 +1,12 @@
+package fr.paris.lutece.portal.web.includes;
+
+public class LinksIncludeTestCacheDisabled extends LinksIncludeTest
+{
+
+    @Override
+    public boolean enableCache( )
+    {
+        return false;
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTestCacheEnabled.java
+++ b/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTestCacheEnabled.java
@@ -1,0 +1,12 @@
+package fr.paris.lutece.portal.web.includes;
+
+public class LinksIncludeTestCacheEnabled extends LinksIncludeTest
+{
+
+    @Override
+    public boolean enableCache( )
+    {
+        return true;
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTestPlugin.java
+++ b/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTestPlugin.java
@@ -1,0 +1,136 @@
+package fr.paris.lutece.portal.web.includes;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import fr.paris.lutece.portal.service.plugin.PluginDefaultImplementation;
+
+public final class LinksIncludeTestPlugin extends PluginDefaultImplementation
+{
+
+    private Map<Integer, List<String>> _listCssStyleSheets = new HashMap<>( );
+    private Map<Integer, List<String>> _listJavascriptFiles = new HashMap<>( );
+    private boolean _cssStyleSheetsScopePortal;
+    private boolean _cssStylesheetsScopeXPage;
+    private boolean _javascriptFilesScopePortal;
+    private boolean _javascriptFilesScopeXPage;
+
+    @Override
+    public List<String> getCssStyleSheets( )
+    {
+        List<String> res = _listCssStyleSheets.get( null );
+
+        if ( res == null )
+        {
+            return Collections.emptyList( );
+        }
+
+        return res;
+    }
+
+    @Override
+    public List<String> getCssStyleSheets( int mode )
+    {
+        List<String> res = _listCssStyleSheets.get( mode );
+
+        if ( res == null )
+        {
+            return Collections.emptyList( );
+        }
+
+        return res;
+    }
+
+    @Override
+    public List<String> getJavascriptFiles( )
+    {
+        List<String> res = _listJavascriptFiles.get( null );
+
+        if ( res == null )
+        {
+            return Collections.emptyList( );
+        }
+
+        return res;
+    }
+
+    @Override
+    public List<String> getJavascriptFiles( int mode )
+    {
+        List<String> res = _listJavascriptFiles.get( mode );
+
+        if ( res == null )
+        {
+            return Collections.emptyList( );
+        }
+
+        return res;
+    }
+
+    public void setCssStyleSheetsScopePortal( boolean bScope )
+    {
+        _cssStyleSheetsScopePortal = bScope;
+    }
+
+    @Override
+    public boolean isCssStylesheetsScopePortal( )
+    {
+        return _cssStyleSheetsScopePortal;
+    }
+
+    public void setCssStylesheetsScopeXPage( boolean bScope )
+    {
+        _cssStylesheetsScopeXPage = bScope;
+    }
+
+    @Override
+    public boolean isCssStylesheetsScopeXPage( )
+    {
+        return _cssStylesheetsScopeXPage;
+    }
+
+    public void setJavascriptFilesScopePortal( boolean bScope )
+    {
+        _javascriptFilesScopePortal = bScope;
+    }
+
+    @Override
+    public boolean isJavascriptFilesScopePortal( )
+    {
+        return _javascriptFilesScopePortal;
+    }
+
+    public void setJavascriptFilesScopeXPage( boolean bScope )
+    {
+        _javascriptFilesScopeXPage = bScope;
+    }
+
+    @Override
+    public boolean isJavascriptFilesScopeXPage( )
+    {
+        return _javascriptFilesScopeXPage;
+    }
+
+    public void setCssStyleSheets( int mode, List<String> styleSheets )
+    {
+        _listCssStyleSheets.put( mode, styleSheets );
+    }
+
+    public void setCssStyleSheets( List<String> styleSheets )
+    {
+        _listCssStyleSheets.put( null, styleSheets );
+    }
+
+    public void setJavascriptFiles( int mode, List<String> javascriptFiles )
+    {
+        _listJavascriptFiles.put( mode, javascriptFiles );
+    }
+
+    public void setJavascriptFiles( List<String> javascriptFiles )
+    {
+        _listJavascriptFiles.put( null, javascriptFiles );
+    }
+
+}

--- a/webapp/WEB-INF/conf/caches.dat
+++ b/webapp/WEB-INF/conf/caches.dat
@@ -20,3 +20,4 @@ BaseUserPreferencesCacheService.maxElementsInMemory=1000
 LuteceUserCacheService.enabled=1
 LuteceUserCacheService.maxElementsInMemory=1000
 pathCacheService.enabled=1
+LinksIncludeCacheService.enabled=1

--- a/webapp/WEB-INF/conf/core_context.xml
+++ b/webapp/WEB-INF/conf/core_context.xml
@@ -44,6 +44,8 @@
     <bean id="pageCacheService" class="fr.paris.lutece.portal.service.page.PageCacheService" />
     <bean id="portletCacheService" class="fr.paris.lutece.portal.service.page.PortletCacheService" />
 
+    <bean id="LinksIncludeCacheService" class="fr.paris.lutece.portal.web.includes.LinksIncludeCacheService" />
+
 	<!-- since the PageService constructor initializes the two above caches, we choose to inject them through the constructor -->
     <bean id="pageService" class="fr.paris.lutece.portal.service.page.PageService" autowire="constructor">
         <property name="pageCacheKeyService" ref="pageCacheKeyService" />

--- a/webapp/WEB-INF/templates/skin/site/plugin_css_link.html
+++ b/webapp/WEB-INF/templates/skin/site/plugin_css_link.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet"  href="${css_prefix}${plugin_css_stylesheet}" type="text/css"  media="screen" />
+<link rel="stylesheet"  href="${plugin_css_stylesheet}" type="text/css"  media="screen" />

--- a/webapp/WEB-INF/templates/skin/site/plugin_javascript_link.html
+++ b/webapp/WEB-INF/templates/skin/site/plugin_javascript_link.html
@@ -1,1 +1,1 @@
-<script src="js/plugins/${plugin_javascript_file}" type="text/javascript" ></script>
+<script src="${plugin_javascript_file}" type="text/javascript" ></script>


### PR DESCRIPTION
If the file is local, compute the SHA-256 hash of its content, and append it as a query parameter to the URL of the included script or css.
While doing so, make absolute URL handling more correct (by handling https and protocol relative URLs), and more uniform between CSS and JS files.

Introduce a cache for links include to offset the cost of hash calculation.