### PR TITLE
LUTECE-2128 : fix path.image.page.template default value

### DIFF
--- a/webapp/WEB-INF/conf/lutece.properties
+++ b/webapp/WEB-INF/conf/lutece.properties
@@ -74,7 +74,7 @@ path.i18n.override=/WEB-INF/conf/override/
 path.images.pages=/images/local/data/pages
 path.images.admin=/images/admin/skin
 path.images.root=/images
-path.image.page.template=/images/admin/page_templates
+path.image.page.template=/images/admin/skin/page_templates
 
 path.jsp.root=/jsp
 path.jsp.site=/jsp/site


### PR DESCRIPTION
Commit 85a3fedf8c046ec165dcdadcb0dcada531e3d3b2 (svn r43849) removed webapp/images/admin/page_templates and moved to images/local/skin/page_templates in commit eeb6d22cf37fb7cd9661b2f19a733f034e5838ca (svn r43873).
But the key path.image.page.template in webapp/WEB-INF/conf/lutece.properties was not updated.