### PR TITLE
LUTECE-2209: upgrade javassist 3.1.12.GA to 3.23.1-GA to fix errors o…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,18 @@
             <groupId>org.scannotation</groupId>
             <artifactId>scannotation</artifactId>
             <version>1.0.3</version>
+            <exclusions>
+              <exclusion>
+                <!-- javassist:javassist relocated to org.javassist:javassist -->
+                <groupId>javassist</groupId>
+                <artifactId>javassist</artifactId>
+              </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.23.1-GA</version>
         </dependency>
 
         <!-- JSON -->


### PR DESCRIPTION
…n java8 constructs (e.g. Method Reference)