### PR TITLE
LUTECE-2224 : Allow client calls to pass StringBuffer to SearchIndexe…

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/search/IndexationService.java
+++ b/src/java/fr/paris/lutece/portal/service/search/IndexationService.java
@@ -293,7 +293,7 @@ public final class IndexationService
                     _sbLogs.append( "</strong>\r\n" );
 
                     // the indexer will call write(doc)
-                    indexer.indexDocuments( );
+                    indexer.indexDocuments( _sbLogs );
                 }
             }
             catch( Exception e )
@@ -363,7 +363,7 @@ public final class IndexationService
 
         // reindexing all pages.
         _writer.deleteDocuments( new Term( SearchItem.FIELD_TYPE, PARAM_TYPE_PAGE ) );
-        _mapIndexers.get( PageIndexer.INDEXER_NAME ).indexDocuments( );
+        _mapIndexers.get( PageIndexer.INDEXER_NAME ).indexDocuments( _sbLogs );
     }
 
     /**

--- a/src/java/fr/paris/lutece/portal/service/search/SearchIndexer.java
+++ b/src/java/fr/paris/lutece/portal/service/search/SearchIndexer.java
@@ -58,6 +58,21 @@ public interface SearchIndexer
      */
     void indexDocuments( ) throws IOException, InterruptedException, SiteMessageException;
 
+	/**
+     * Index all lucene documents from the plugin, replace List&lt;Document&gt; getDocuments( ) method
+     *
+     * @param sbLogs
+     *          Le logger
+     * @throws IOException
+     *             If an IO error occured
+     * @throws InterruptedException
+     *             If a thread error occured
+     * @throws SiteMessageException
+     *             occurs when a site message need to be displayed
+     */
+    default void indexDocuments( StringBuffer sbLogs ) throws IOException, InterruptedException, SiteMessageException {
+        indexDocuments(  );
+    }
     /**
      * Returns a List of lucene documents to add to the index
      * 

--- a/src/java/fr/paris/lutece/portal/service/search/SearchIndexer.java
+++ b/src/java/fr/paris/lutece/portal/service/search/SearchIndexer.java
@@ -70,7 +70,8 @@ public interface SearchIndexer
      * @throws SiteMessageException
      *             occurs when a site message need to be displayed
      */
-    default void indexDocuments( StringBuffer sbLogs ) throws IOException, InterruptedException, SiteMessageException {
+    default void indexDocuments( StringBuffer sbLogs ) throws IOException, InterruptedException, SiteMessageException 
+	{
         indexDocuments(  );
     }
     /**


### PR DESCRIPTION
The goal is to have the logs on blog indexation and not impact the other clients : 

BEFORE  : ![image](https://user-images.githubusercontent.com/40595941/52117373-d7e73a00-2613-11e9-8953-22253b165193.png)

AFTER : 
![image](https://user-images.githubusercontent.com/40595941/52117387-e2093880-2613-11e9-8864-32d89762d341.png)
