### PR TITLE
Fixed tests for compatibility with both java 8 and java 10+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,28 @@
             <artifactId>library-jmx-api</artifactId>
             <version>1.0.0</version>
         </dependency>
+
+        <!-- JAXB dependencies (required for Java 9+) -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/src/test/java/fr/paris/lutece/portal/service/i18n/I18nServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/i18n/I18nServiceTest.java
@@ -101,9 +101,10 @@ public class I18nServiceTest extends LuteceTestCase
         Locale locale = Locale.FRENCH;
         int nDateFormat = DateFormat.SHORT;
 
-        String expResult = "01/01/70";
-        String result = fr.paris.lutece.portal.service.i18n.I18nService.getLocalizedDate( date, locale, nDateFormat );
-        assertEquals( expResult, result );
+	String expResultJava8 = "01/01/70";
+	String expResultJava10 = "01/01/1970";
+	String result = fr.paris.lutece.portal.service.i18n.I18nService.getLocalizedDate( date, locale, nDateFormat );
+	assertTrue(expResultJava8.equals(result) || expResultJava10.equals(result));
     }
 
     /**
@@ -118,9 +119,10 @@ public class I18nServiceTest extends LuteceTestCase
         int nDateFormat = DateFormat.SHORT;
         int nTimeFormat = DateFormat.SHORT;
 
-        String expResult = "01/01/70 01:00";
+        String expResultJava8 = "01/01/70 01:00";
+        String expResultJava10 = "01/01/1970 01:00";
         String result = fr.paris.lutece.portal.service.i18n.I18nService.getLocalizedDateTime( date, locale, nDateFormat, nTimeFormat );
-        assertEquals( expResult, result );
+        assertTrue(expResultJava8.equals(result) || expResultJava10.equals(result));
     }
 
     /**

--- a/src/test/java/fr/paris/lutece/portal/service/template/AbstractMessageFormatTemplateMethodTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/template/AbstractMessageFormatTemplateMethodTest.java
@@ -96,12 +96,16 @@ public class AbstractMessageFormatTemplateMethodTest extends LuteceTestCase
         model.put( "arg", new Date( 123456789 ) );
         res = FreeMarkerTemplateService.getInstance( ).loadTemplate( template, Locale.FRANCE, model );
         assertNotNull( res );
-        assertEquals( "test with quote and arg 02/01/70 11:17", res.getHtml( ) );
+        String expResultJava8 = "test with quote and arg 02/01/70 11:17";
+        String expResultJava10 = "test with quote and arg 02/01/1970 11:17";
+        assertTrue(expResultJava8.equals(res.getHtml()) || expResultJava10.equals(res.getHtml()));
 
         model.put( "arg", new Date( 123456789 ) );
         res = FreeMarkerTemplateService.getInstance( ).loadTemplate( template, Locale.US, model );
         assertNotNull( res );
-        assertEquals( "test with quote and arg 1/2/70 11:17 AM", res.getHtml( ) );
+        expResultJava8 = "test with quote and arg 1/2/70 11:17 AM";
+        expResultJava10 = "test with quote and arg 1/2/70, 11:17 AM";
+        assertTrue(expResultJava8.equals(res.getHtml()) || expResultJava10.equals(res.getHtml()));
     }
 
 }


### PR DESCRIPTION
Works on both platforms, but requires jacoco 0.8.2+ in parent POM for Java10. Note that Jacoco 0.8.2 should be OK on Java8 as well.