### PR TITLE
Allow for multiple environment variable substitutions in a string

### DIFF
--- a/src/java/fr/paris/lutece/util/env/EnvUtil.java
+++ b/src/java/fr/paris/lutece/util/env/EnvUtil.java
@@ -82,7 +82,8 @@ public final class EnvUtil
     {
         String strOutput = ( strSource != null ) ? strSource : "";
         Matcher matcher = _pattern.matcher( strOutput );
-        
+        int offset = 0;
+
         while ( matcher.find( ) )
         {
             String strMarker = matcher.group();
@@ -92,7 +93,9 @@ public final class EnvUtil
             {
                 strValue = getFileContent( strValue );
             }
-             strOutput = strOutput.substring( 0 , matcher.start() ) + strValue + strOutput.substring( matcher.end() );
+            strValue = strValue==null? "" : strValue;
+            strOutput = strOutput.substring( 0 , matcher.start() + offset ) + strValue + strOutput.substring( matcher.end() + offset );
+            offset += strValue.length() - strMarker.length();
         }
         return strOutput;
     }

--- a/src/test/java/fr/paris/lutece/util/env/EnvUtilTest.java
+++ b/src/test/java/fr/paris/lutece/util/env/EnvUtilTest.java
@@ -48,6 +48,8 @@ import static org.junit.Assert.*;
  */
 public class EnvUtilTest
 {
+    private static final String ENV_LUTECE_DB_HOST_VAR = "LUTECE_HOST";
+    private static final String ENV_LUTECE_DB_HOST_VALUE = "mysql";
     private static final String ENV_LUTECE_DB_USER_VAR = "LUTECE_DB_USER";
     private static final String ENV_LUTECE_DB_USER_VALUE = "lutece_user";
     private static final String ENV_LUTECE_DB_NAME_VAR = "LUTECE_DATABASE";
@@ -56,8 +58,8 @@ public class EnvUtilTest
     private static final String ENV_LUTECE_DB_PWD_FILE_VALUE = "./fr/paris/lutece/util/env/password.txt";
     private static final String PASSWORD = "${LUTECE_DB_PWD_FILE}";
     private static final String PASSWORD_EXPECTED = "change me";
-    private static final String URL = "jdbc:mysql://localhost/${LUTECE_DATABASE}?autoReconnect=true&useUnicode=yes&characterEncoding=utf8";
-    private static final String URL_EXPECTED = "jdbc:mysql://localhost/lutece?autoReconnect=true&useUnicode=yes&characterEncoding=utf8";
+    private static final String URL = "jdbc:mysql://${LUTECE_HOST}/${LUTECE_DATABASE}?autoReconnect=true&useUnicode=yes&characterEncoding=utf8";
+    private static final String URL_EXPECTED = "jdbc:mysql://mysql/lutece?autoReconnect=true&useUnicode=yes&characterEncoding=utf8";
 
     /**
      * Test of evaluate method, of class EnvUtil.
@@ -71,6 +73,7 @@ public class EnvUtilTest
         Map<String, String> mapEnv = new HashMap<>();
         mapEnv.put( ENV_LUTECE_DB_USER_VAR, ENV_LUTECE_DB_USER_VALUE);
         mapEnv.put( ENV_LUTECE_DB_NAME_VAR, ENV_LUTECE_DB_NAME_VALUE );
+        mapEnv.put( ENV_LUTECE_DB_HOST_VAR, ENV_LUTECE_DB_HOST_VALUE );
         URL url = getClass().getClassLoader().getResource( ENV_LUTECE_DB_PWD_FILE_VALUE );
         File file = Paths.get(url.toURI()).toFile();
         mapEnv.put( ENV_LUTECE_DB_PWD_FILE_VAR, file.getAbsolutePath() );


### PR DESCRIPTION
When more than one environment variable substitution is made in a string in EnvUtil.evaluate(), the offsets for the start and end of a match are incorrect, because they are indexed relative to the initial string, and not the string modified by earlier substitutions. We correct this by adjusting the offset by the accumulation of differences between the lengths of the replacement strings and the replaced strings