### PR TITLE
LUTECE-2297: use auto incremented core_page ids in init script

### DIFF
--- a/src/sql/init_db_lutece_core.sql
+++ b/src/sql/init_db_lutece_core.sql
@@ -71,8 +71,8 @@ INSERT INTO core_mode VALUES (0,'Normal','normal/','xml','1.0','text/xml','UTF-8
 INSERT INTO core_mode VALUES (1,'Administration','admin/','xml','1.0','text/xml','UTF-8','yes','yes','yes');
 INSERT INTO core_mode VALUES (2,'Wap','wml/','xml','1.0','text/xml','UTF-8','yes','yes','yes');
 
-INSERT INTO core_page  VALUES (1,0,'Home','Home Page','2014-06-08 17:20:44',1,1,4,'2003-09-09 00:38:01','none','default',0,'','application/octet-stream',NULL,NULL,1,0,0);
-INSERT INTO core_page  VALUES (2,1,'Page 1','A child page','2014-06-08 18:23:42',0,1,2,'2014-06-08 18:23:42','none','default',1,NULL,'application/octet-stream',NULL,NULL,1,0,0);
+INSERT INTO core_page (id_parent,name,description,date_update,status,page_order,id_template,date_creation,role,code_theme,node_status,image_content,mime_type,meta_keywords,meta_description,id_authorization_node,display_date_update,is_manual_date_update) VALUES (0,'Home','Home Page','2014-06-08 17:20:44',1,1,4,'2003-09-09 00:38:01','none','default',0,'','application/octet-stream',NULL,NULL,1,0,0);
+INSERT INTO core_page (id_parent,name,description,date_update,status,page_order,id_template,date_creation,role,code_theme,node_status,image_content,mime_type,meta_keywords,meta_description,id_authorization_node,display_date_update,is_manual_date_update) VALUES (1,'Page 1','A child page','2014-06-08 18:23:42',0,1,2,'2014-06-08 18:23:42','none','default',1,NULL,'application/octet-stream',NULL,NULL,1,0,0);
 
 INSERT INTO core_page_template VALUES (1,'One column','skin/site/page_template1.html','page_template1.gif');
 INSERT INTO core_page_template VALUES (2,'Two columns','skin/site/page_template2.html','page_template2.gif');


### PR DESCRIPTION
PostreSQL does not alter the auto_increment sequence when the id is forced.
This would cause duplicate ids errors when creating pages.