### PR TITLE
LUTECE-2298: use auto incremented core_admin_user ids in init

### DIFF
--- a/src/sql/init_db_lutece_core.sql
+++ b/src/sql/init_db_lutece_core.sql
@@ -44,10 +44,10 @@ INSERT INTO core_admin_role_resource VALUES (137,'all_site_manager', 'SEARCH_SER
 INSERT INTO core_admin_role_resource VALUES (164,'all_site_manager', 'XSL_EXPORT', '*', '*');
 
 -- default accounts; password storage will be upgraded on first login
-INSERT INTO core_admin_user VALUES (1,'admin','Admin','admin','admin@lutece.fr',0,'PLAINTEXT:adminadmin','fr',0,0,0,'1980-01-01 00:00:00',null,0,'1980-01-01 00:00:00','all');
-INSERT INTO core_admin_user VALUES (2,'lutece','Lutèce','lutece','lutece@lutece.fr',1,'PLAINTEXT:adminadmin','fr',1,0,0,'1980-01-01 00:00:00',null,0,'1980-01-01 00:00:00','all');
-INSERT INTO core_admin_user VALUES (3,'redac','redac','redac','redac@lutece.fr',1,'PLAINTEXT:adminadmin','fr',2,0,0,'1980-01-01 00:00:00',null,0,'1980-01-01 00:00:00','all');
-INSERT INTO core_admin_user VALUES (4,'valid','valid','valid','valid@lutece.fr',1,'PLAINTEXT:adminadmin','fr',3,0,0,'1980-01-01 00:00:00',null,0,'1980-01-01 00:00:00','all');
+INSERT INTO core_admin_user (access_code,last_name,first_name,email,status,password,locale,level_user,reset_password,accessibility_mode,password_max_valid_date,account_max_valid_date,nb_alerts_sent,last_login,workgroup_key) VALUES ('admin','Admin','admin','admin@lutece.fr',0,'PLAINTEXT:adminadmin','fr',0,0,0,'1980-01-01 00:00:00',null,0,'1980-01-01 00:00:00','all');
+INSERT INTO core_admin_user (access_code,last_name,first_name,email,status,password,locale,level_user,reset_password,accessibility_mode,password_max_valid_date,account_max_valid_date,nb_alerts_sent,last_login,workgroup_key) VALUES ('lutece','Lutèce','lutece','lutece@lutece.fr',1,'PLAINTEXT:adminadmin','fr',1,0,0,'1980-01-01 00:00:00',null,0,'1980-01-01 00:00:00','all');
+INSERT INTO core_admin_user (access_code,last_name,first_name,email,status,password,locale,level_user,reset_password,accessibility_mode,password_max_valid_date,account_max_valid_date,nb_alerts_sent,last_login,workgroup_key) VALUES ('redac','redac','redac','redac@lutece.fr',1,'PLAINTEXT:adminadmin','fr',2,0,0,'1980-01-01 00:00:00',null,0,'1980-01-01 00:00:00','all');
+INSERT INTO core_admin_user (access_code,last_name,first_name,email,status,password,locale,level_user,reset_password,accessibility_mode,password_max_valid_date,account_max_valid_date,nb_alerts_sent,last_login,workgroup_key) VALUES ('valid','valid','valid','valid@lutece.fr',1,'PLAINTEXT:adminadmin','fr',3,0,0,'1980-01-01 00:00:00',null,0,'1980-01-01 00:00:00','all');
 
 INSERT INTO core_dashboard(dashboard_name, dashboard_column, dashboard_order) VALUES('CORE_SYSTEM', 1, 2);
 INSERT INTO core_dashboard(dashboard_name, dashboard_column, dashboard_order) VALUES('CORE_USERS', 1, 1);


### PR DESCRIPTION
PostreSQL does not alter the auto_increment sequence when the id is forced.
This would cause duplicate ids errors when creating users.