### PR TITLE
LUTECE-2300 : freeMarkerTemplateService.init expects a path starting …

### DIFF
--- a/src/test/java/fr/paris/lutece/portal/service/template/FreeMarkerTemplateServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/template/FreeMarkerTemplateServiceTest.java
@@ -54,7 +54,7 @@ public class FreeMarkerTemplateServiceTest extends LuteceTestCase
      */
     public void testInit( )
     {
-        String strTemplatePath = "WEB-INF/templates/";
+        String strTemplatePath = "/WEB-INF/templates/";
 
         IFreeMarkerTemplateService freeMarkerTemplateService = FreeMarkerTemplateService.getInstance( );
 


### PR DESCRIPTION
…with a /