### PR TITLE
LUTECE-2305: Increase the timeout in the test

### DIFF
--- a/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
@@ -49,7 +49,7 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
     private static final long TIMEOUT_DURATION = 10L;
     private static final TimeUnit TIMEOUT_TIMEUNIT = TimeUnit.SECONDS;
     private boolean _runnableTimedOut;
-    private Boolean _bThreadLuancherDaemonInitialState;
+    private Boolean _bThreadLauncherDaemonInitialState;
     private DaemonEntry _threadLauncherDaemonEntry;
 
     @Override
@@ -57,16 +57,17 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
     {
         super.setUp( );
         // we ensure the ThreadLauncherDeamon is started
+        AppLogService.info( "Ensure ThreadLauncherDeamon is started" );
         for ( DaemonEntry daemonEntry : AppDaemonService.getDaemonEntries( ) )
         {
             if ( daemonEntry.getId( ).equals( "threadLauncherDaemon" ) )
             {
                 _threadLauncherDaemonEntry = daemonEntry;
-                _bThreadLuancherDaemonInitialState = daemonEntry.isRunning( );
+                _bThreadLauncherDaemonInitialState = daemonEntry.isRunning( );
                 break;
             }
         }
-        assertNotNull( "Did not find threadLauncherDaemon daemon", _bThreadLuancherDaemonInitialState );
+        assertNotNull( "Did not find threadLauncherDaemon daemon", _bThreadLauncherDaemonInitialState );
         AppDaemonService.startDaemon( "threadLauncherDaemon" );
     }
 
@@ -74,7 +75,8 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
     protected void tearDown( ) throws Exception
     {
         // restore threadLauncherDaemon state
-        if ( !_bThreadLuancherDaemonInitialState.booleanValue( ) )
+        AppLogService.info( "restore threadLauncherDaemon state (" + _bThreadLauncherDaemonInitialState + ")" );
+        if ( !_bThreadLauncherDaemonInitialState.booleanValue( ) )
         {
             AppDaemonService.stopDaemon( "threadLauncherDaemon" );
         }

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
@@ -90,6 +90,9 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
     {
         CyclicBarrier barrier = new CyclicBarrier( 2 );
         _runnableTimedOut = false;
+        
+        dumpStateWhileWaiting( 0L ); // for debugging test failure
+        
         Instant start = Instant.now( );
         ThreadLauncherDaemon.addItemToQueue( ( ) -> {
             try
@@ -103,7 +106,7 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
             }
         }, "key", PluginService.getCore( ) );
 
-        dumpStateWhileWaiting( ); // for debugging test failure
+        dumpStateWhileWaiting( 500L ); // for debugging test failure
 
         barrier.await( TIMEOUT_DURATION, TIMEOUT_TIMEUNIT );
         AppLogService.info( "ThreadLauncherDaemonTest#testAddItemToQueue : task executed after "
@@ -112,10 +115,10 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
         assertFalse( _runnableTimedOut );
     }
 
-    private void dumpStateWhileWaiting( ) throws InterruptedException
+    private void dumpStateWhileWaiting( long lWait ) throws InterruptedException
     {
         // wait for the daemon to have a chance to try running
-        Thread.sleep( 1000 );
+        Thread.sleep( lWait );
         final StringBuilder dump = new StringBuilder( );
         final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean( );
         final ThreadInfo[ ] threadInfos = threadMXBean.getThreadInfo( threadMXBean.getAllThreadIds( ), 100 );

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
@@ -114,7 +114,7 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
     private void dumpStateWhileWaiting( ) throws InterruptedException
     {
         // wait for the daemon to have a chance to try running
-        Thread.sleep( 500 );
+        Thread.sleep( 1000 );
         final StringBuilder dump = new StringBuilder( );
         final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean( );
         final ThreadInfo[ ] threadInfos = threadMXBean.getThreadInfo( threadMXBean.getAllThreadIds( ), 100 );

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
@@ -94,6 +94,7 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
         ThreadLauncherDaemon.addItemToQueue( ( ) -> {
             try
             {
+                AppLogService.info( "testAddItemToQueue: Inside the task, going to await" );
                 barrier.await( TIMEOUT_DURATION, TIMEOUT_TIMEUNIT );
             }
             catch ( InterruptedException | BrokenBarrierException | TimeoutException e )

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
@@ -33,33 +33,41 @@
  */
 package fr.paris.lutece.portal.service.daemon;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import fr.paris.lutece.portal.service.plugin.PluginService;
+import fr.paris.lutece.portal.service.util.AppLogService;
 import fr.paris.lutece.test.LuteceTestCase;
 
 public class ThreadLauncherDaemonTest extends LuteceTestCase
 {
+    private static final long TIMEOUT_DURATION = 10L;
+    private static final TimeUnit TIMEOUT_TIMEUNIT = TimeUnit.SECONDS;
     private boolean _runnableTimedOut;
 
     public void testAddItemToQueue( ) throws InterruptedException, BrokenBarrierException, TimeoutException
     {
         CyclicBarrier barrier = new CyclicBarrier( 2 );
         _runnableTimedOut = false;
+        Instant start = Instant.now( );
         ThreadLauncherDaemon.addItemToQueue( ( ) -> {
             try
             {
-                barrier.await( 10L, TimeUnit.SECONDS );
+                barrier.await( TIMEOUT_DURATION, TIMEOUT_TIMEUNIT );
             }
-            catch( InterruptedException | BrokenBarrierException | TimeoutException e )
+            catch ( InterruptedException | BrokenBarrierException | TimeoutException e )
             {
                 _runnableTimedOut = true;
             }
         }, "key", PluginService.getCore( ) );
-        barrier.await( 250L, TimeUnit.MILLISECONDS );
+        barrier.await( TIMEOUT_DURATION, TIMEOUT_TIMEUNIT );
+        AppLogService.info( "ThreadLauncherDaemonTest#testAddItemToQueue : task executed after "
+                + Duration.between( start, Instant.now( ) ).toMillis( ) + "ms" );
         assertFalse( _runnableTimedOut );
     }
 }

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
@@ -113,7 +113,7 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
 
     private void dumpStateWhileWaiting( ) throws InterruptedException
     {
-        // wait for thea daemon to have a chance to try running
+        // wait for the daemon to have a chance to try running
         Thread.sleep( 500 );
         final StringBuilder dump = new StringBuilder( );
         final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean( );

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/ThreadLauncherDaemonTest.java
@@ -49,6 +49,37 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
     private static final long TIMEOUT_DURATION = 10L;
     private static final TimeUnit TIMEOUT_TIMEUNIT = TimeUnit.SECONDS;
     private boolean _runnableTimedOut;
+    private Boolean _bThreadLuancherDaemonInitialState;
+    private DaemonEntry _threadLauncherDaemonEntry;
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        // we ensure the ThreadLauncherDeamon is started
+        for ( DaemonEntry daemonEntry : AppDaemonService.getDaemonEntries( ) )
+        {
+            if ( daemonEntry.getId( ).equals( "threadLauncherDaemon" ) )
+            {
+                _threadLauncherDaemonEntry = daemonEntry;
+                _bThreadLuancherDaemonInitialState = daemonEntry.isRunning( );
+                break;
+            }
+        }
+        assertNotNull( "Did not find threadLauncherDaemon daemon", _bThreadLuancherDaemonInitialState );
+        AppDaemonService.startDaemon( "threadLauncherDaemon" );
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        // restore threadLauncherDaemon state
+        if ( !_bThreadLuancherDaemonInitialState.booleanValue( ) )
+        {
+            AppDaemonService.stopDaemon( "threadLauncherDaemon" );
+        }
+        super.tearDown( );
+    }
 
     public void testAddItemToQueue( ) throws InterruptedException, BrokenBarrierException, TimeoutException
     {
@@ -68,6 +99,7 @@ public class ThreadLauncherDaemonTest extends LuteceTestCase
         barrier.await( TIMEOUT_DURATION, TIMEOUT_TIMEUNIT );
         AppLogService.info( "ThreadLauncherDaemonTest#testAddItemToQueue : task executed after "
                 + Duration.between( start, Instant.now( ) ).toMillis( ) + "ms" );
+        AppLogService.info( "Last Run Logs : " + _threadLauncherDaemonEntry.getLastRunLogs( ) );
         assertFalse( _runnableTimedOut );
     }
 }


### PR DESCRIPTION
250ms seems too small when executing in Jenkins. Plus it makes no sense to have a different timeout for the task and for the test.
Unfiy the timeouts, retaining the large value. Add logging to assess the time spent in the test.