### PR TITLE
LUTECE-2305: Allow daemons to run concurrently

### DIFF
--- a/src/test/java/fr/paris/lutece/portal/service/daemon/AppDaemonServiceConcurrentTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/AppDaemonServiceConcurrentTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2002-2020, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.daemon;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.TimeoutException;
+
+import fr.paris.lutece.portal.service.datastore.DatastoreService;
+import fr.paris.lutece.portal.service.util.AppLogService;
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class AppDaemonServiceConcurrentTest extends LuteceTestCase
+{
+    private static final String INTERVAL_VALUE = "10000";
+    private static final String JUNIT_DAEMON = "JUNIT";
+    private static final String JUNIT_OTHERDAEMON = "OTHERJUNIT";
+    private static final String DAEMON_INTERVAL_DSKEY = "core.daemon." + JUNIT_DAEMON + ".interval";
+    private static final String OTHERDAEMON_INTERVAL_DSKEY = "core.daemon." + JUNIT_OTHERDAEMON + ".interval";
+
+    private DaemonEntry _entry;
+    private DaemonEntry _otherEntry;
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        log( "Creating daemon " + JUNIT_DAEMON );
+        _entry = new DaemonEntry( );
+        _entry.setId( JUNIT_DAEMON );
+        _entry.setNameKey( JUNIT_DAEMON );
+        _entry.setDescriptionKey( JUNIT_DAEMON );
+        _entry.setClassName( TestDaemon.class.getName( ) );
+        _entry.setPluginName( "core" );
+        // AppDaemonService.registerDaemon will copy this datastore value in the
+        // entry.
+        DatastoreService.setInstanceDataValue( DAEMON_INTERVAL_DSKEY, INTERVAL_VALUE );
+        AppDaemonService.registerDaemon( _entry );
+
+        log( "Creating daemon " + JUNIT_OTHERDAEMON );
+        _otherEntry = new DaemonEntry( );
+        _otherEntry.setId( JUNIT_OTHERDAEMON );
+        _otherEntry.setNameKey( JUNIT_OTHERDAEMON );
+        _otherEntry.setDescriptionKey( JUNIT_OTHERDAEMON );
+        _otherEntry.setClassName( TestConcurrentDaemon.class.getName( ) );
+        _otherEntry.setPluginName( "core" );
+        // AppDaemonService.registerDaemon will copy this datastore value in the
+        // entry.
+        DatastoreService.setInstanceDataValue( OTHERDAEMON_INTERVAL_DSKEY, INTERVAL_VALUE );
+        AppDaemonService.registerDaemon( _otherEntry );
+    }
+
+    private void log( String message )
+    {
+        AppLogService.info( this.getClass( ).getName( ) + ": " + message );
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        DatastoreService.removeInstanceData( DAEMON_INTERVAL_DSKEY );
+        AppDaemonService.stopDaemon( JUNIT_DAEMON );
+        AppDaemonService.unregisterDaemon( JUNIT_DAEMON );
+        DatastoreService.removeInstanceData( OTHERDAEMON_INTERVAL_DSKEY );
+        AppDaemonService.stopDaemon( JUNIT_OTHERDAEMON );
+        AppDaemonService.unregisterDaemon( JUNIT_OTHERDAEMON );
+        super.tearDown( );
+    }
+
+    public void testConcurrentDaemonRun( )
+    {
+        assertTrue( AppDaemonService.getDaemonEntries( ).contains( _entry ) );
+        assertTrue( AppDaemonService.getDaemonEntries( ).contains( _otherEntry ) );
+
+        AppDaemonService.startDaemon( JUNIT_DAEMON );
+        AppDaemonService.startDaemon( JUNIT_OTHERDAEMON );
+
+        final TestDaemon daemon = ( TestDaemon ) _entry.getDaemon( );
+        ( ( TestConcurrentDaemon ) _otherEntry.getDaemon( ) ).setOther( daemon );
+
+        AppDaemonService.signalDaemon( JUNIT_DAEMON );
+        AppDaemonService.signalDaemon( JUNIT_OTHERDAEMON );
+        try
+        {
+            // daemon only passes the "go" barrier if otherDeamon runs
+            daemon.waitForCompletion( );
+        }
+        catch ( InterruptedException | BrokenBarrierException | TimeoutException e )
+        {
+            fail( "The timeout indicates that the two daemons could not run simultaneously" );
+        }
+
+    }
+}

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/TestConcurrentDaemon.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/TestConcurrentDaemon.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2020, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.daemon;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.TimeoutException;
+
+public final class TestConcurrentDaemon extends Daemon
+{
+    private TestDaemon _other;
+
+    public void setOther( TestDaemon other )
+    {
+        _other = other;
+    }
+
+    @Override
+    public void run( )
+    {
+        try
+        {
+            // wait for other to start
+            _other.go( );
+        }
+        catch ( InterruptedException | BrokenBarrierException | TimeoutException e )
+        {
+            // TODO Auto-generated catch block
+            e.printStackTrace( );
+        }
+    }
+
+}

--- a/webapp/WEB-INF/conf/core_context.xml
+++ b/webapp/WEB-INF/conf/core_context.xml
@@ -209,13 +209,13 @@
 
     <!-- Daemon management -->
     <bean id="daemonQueue" class="java.util.concurrent.LinkedBlockingQueue" />
-    <bean id="daemonExecutorQueue" class="java.util.concurrent.LinkedBlockingQueue" />
+    <bean id="daemonExecutorQueue" class="java.util.concurrent.SynchronousQueue" />
     <bean id="daemonThreadFactory" class="fr.paris.lutece.portal.service.daemon.DaemonThreadFactory" />
     <bean id="daemonExecutor" class="java.util.concurrent.ThreadPoolExecutor">
-        <constructor-arg index="0" value="${daemon.ScheduledThreadCorePoolSize:30}" /> <!-- corePoolSize -->
+        <constructor-arg index="0" value="${daemon.ScheduledThreadCorePoolSize:1}" /> <!-- corePoolSize -->
         <constructor-arg index="1" value="${daemon.maximumPoolSize:30}" /> <!-- maximumPoolSize -->
-        <constructor-arg index="2" value="${daemon.keepAliveTime:0}" /> <!-- keepAliveTime -->
-        <constructor-arg index="3" value="${daemon.timeUnit:MILLISECONDS}" /> <!-- unit -->
+        <constructor-arg index="2" value="${daemon.keepAliveTime:60}" /> <!-- keepAliveTime -->
+        <constructor-arg index="3" value="${daemon.timeUnit:SECONDS}" /> <!-- unit -->
         <constructor-arg index="4" ref="daemonExecutorQueue" /> <!-- workQueue -->
         <constructor-arg index="5" ref="daemonThreadFactory" /> <!-- threadFactory -->
     </bean>

--- a/webapp/WEB-INF/conf/daemons.properties
+++ b/webapp/WEB-INF/conf/daemons.properties
@@ -17,9 +17,9 @@ daemon.maximumPoolSize=30
 # when the number of threads is greater than
 # the core, maximum time that excess idle threads
 # will wait for new tasks before terminating.
-daemon.keepAliveTime=0
+daemon.keepAliveTime=60
 # the time unit for the daemon.keepAliveTime parameter (see java.util.concurrent.TimeUnit)
-daemon.timeUnit=MILLISECONDS
+daemon.timeUnit=SECONDS
 
 
 ################################################################################


### PR DESCRIPTION
The usage of a LinkedBlockingQueue for the executor prevented new thread from being created (see https://stackoverflow.com/questions/15485840/threadpoolexecutor-with-unbounded-queue-not-creating-new-threads).
The default being 1 thread, there could be only one daemon running at any given time.

Change to SynchronousQueue to model Executors.newCachedThreadPool()
Allow idle threads to stay around for one minute when idle, rather than killing them immediatly.

Add a test.