### PR TITLE
LUTECE-2353: Remove type="text/javascript" from script tag

### DIFF
--- a/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTest.java
+++ b/src/test/java/fr/paris/lutece/portal/web/includes/LinksIncludeTest.java
@@ -471,7 +471,7 @@ public abstract class LinksIncludeTest extends LuteceTestCase
         HttpServletRequest request = new MockHttpServletRequest( );
         include.fillTemplate( rootModel, data, nMode, request );
         String cssLinks = (String) rootModel.get( "plugins_javascript_links" );
-        assertEquals( "<script src=\"js/plugins/linksIncludeTestPlugin/script.js\" type=\"text/javascript\" ></script>", cssLinks.replace("\n", "").replace("\r", "") );
+        assertEquals( "<script src=\"js/plugins/linksIncludeTestPlugin/script.js\"></script>", cssLinks.replace("\n", "").replace("\r", "") );
     }
 
     public void testGetURIJavascriptAbsoluteHttp( )
@@ -488,7 +488,7 @@ public abstract class LinksIncludeTest extends LuteceTestCase
         HttpServletRequest request = new MockHttpServletRequest( );
         include.fillTemplate( rootModel, data, nMode, request );
         String cssLinks = (String) rootModel.get( "plugins_javascript_links" );
-        assertEquals( "<script src=\"http://example.com/script.js\" type=\"text/javascript\" ></script>", cssLinks.replace("\n", "").replace("\r", "") );
+        assertEquals( "<script src=\"http://example.com/script.js\"></script>", cssLinks.replace("\n", "").replace("\r", "") );
     }
 
     public void testGetURIJavascriptAbsoluteHttps( )
@@ -505,7 +505,7 @@ public abstract class LinksIncludeTest extends LuteceTestCase
         HttpServletRequest request = new MockHttpServletRequest( );
         include.fillTemplate( rootModel, data, nMode, request );
         String cssLinks = (String) rootModel.get( "plugins_javascript_links" );
-        assertEquals( "<script src=\"https://example.com/script.js\" type=\"text/javascript\" ></script>", cssLinks.replace("\n", "").replace("\r", "") );
+        assertEquals( "<script src=\"https://example.com/script.js\"></script>", cssLinks.replace("\n", "").replace("\r", "") );
     }
 
     public void testGetURIJavascriptProtocolRelative( )
@@ -522,7 +522,7 @@ public abstract class LinksIncludeTest extends LuteceTestCase
         HttpServletRequest request = new MockHttpServletRequest( );
         include.fillTemplate( rootModel, data, nMode, request );
         String cssLinks = (String) rootModel.get( "plugins_javascript_links" );
-        assertEquals( "<script src=\"//example.com/script.js\" type=\"text/javascript\" ></script>", cssLinks.replace("\n", "").replace("\r", "") );
+        assertEquals( "<script src=\"//example.com/script.js\"></script>", cssLinks.replace("\n", "").replace("\r", "") );
     }
 
     public void testGetURIJavascriptHash( ) throws IOException
@@ -570,7 +570,7 @@ public abstract class LinksIncludeTest extends LuteceTestCase
             include.fillTemplate( rootModel, data, nMode, request );
             String cssLinks = (String) rootModel.get( "plugins_javascript_links" );
             assertEquals(
-                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\" type=\"text/javascript\" ></script>",
+                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\"></script>",
                     cssLinks.replace("\n", "").replace("\r", "") );
             try( FileWriter writer = new FileWriter( hashedFile ) )
             {
@@ -587,7 +587,7 @@ public abstract class LinksIncludeTest extends LuteceTestCase
             {
                 assertFalse( cssLinks.equals( cssLinks2 ) );
                 assertEquals(
-                        "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?lutece_h=531ba794ef006cd3d69cf1acb33ddeccf8d6c655fb08f469335f8c2c32e2ab68\" type=\"text/javascript\" ></script>",
+                        "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?lutece_h=531ba794ef006cd3d69cf1acb33ddeccf8d6c655fb08f469335f8c2c32e2ab68\"></script>",
                         cssLinks2.replace("\n", "").replace("\r", "") );
             }
         }
@@ -642,7 +642,7 @@ public abstract class LinksIncludeTest extends LuteceTestCase
             include.fillTemplate( rootModel, data, nMode, request );
             String cssLinks = (String) rootModel.get( "plugins_javascript_links" );
             assertEquals(
-                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?arg=value&lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\" type=\"text/javascript\" ></script>",
+                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?arg=value&lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\"></script>",
                     cssLinks.replace("\n", "").replace("\r", "") );
         }
         finally
@@ -696,7 +696,7 @@ public abstract class LinksIncludeTest extends LuteceTestCase
             MockHttpServletRequest request = new MockHttpServletRequest( servletContext );
             include.fillTemplate( rootModel, data, nMode, request );
             String cssLinks = (String) rootModel.get( "plugins_javascript_links" );
-            assertEquals( "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js\" type=\"text/javascript\" ></script>", cssLinks.replace("\n", "").replace("\r", "") );
+            assertEquals( "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js\"></script>", cssLinks.replace("\n", "").replace("\r", "") );
         }
         finally
         {
@@ -758,7 +758,7 @@ public abstract class LinksIncludeTest extends LuteceTestCase
             include.fillTemplate( rootModel, data, nMode, request );
             String cssLinks = (String) rootModel.get( "plugins_javascript_links" );
             assertEquals(
-                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\" type=\"text/javascript\" ></script>",
+                    "<script src=\"js/plugins/linksIncludeTestPlugin/scripthashed.js?lutece_h=88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\"></script>",
                     cssLinks.replace("\n", "").replace("\r", "") );
         }
         finally

--- a/webapp/WEB-INF/plugins/document/xsl/document_spaces_tree.xsl
+++ b/webapp/WEB-INF/plugins/document/xsl/document_spaces_tree.xsl
@@ -11,7 +11,7 @@
                 <xsl:apply-templates select="space" />
             </ul>
         </div>
-        <script type="text/javascript">
+        <script>
             jQuery(function($) {
             $("#tree").jstree({"plugins" : [ "themes", "html_data", "cookies" ]});
             });

--- a/webapp/WEB-INF/templates/admin/insert/insert_into_element.html
+++ b/webapp/WEB-INF/templates/admin/insert/insert_into_element.html
@@ -1,5 +1,5 @@
 <!--  Insert service -->
-<script type="text/javascript">
+<script>
 $( function(){
 	var isIt = '${.data_model.input}', insertCode='${insert}';
 	switch ( isIt ) {

--- a/webapp/WEB-INF/templates/admin/insert/insert_into_element2.html
+++ b/webapp/WEB-INF/templates/admin/insert/insert_into_element2.html
@@ -1,5 +1,5 @@
 <div id="tag">${insert}</div>
-<script type="text/javascript">
+<script>
 	// TinyMCE insert
 	var textToInsert = document.getElementById("tag").innerHTML.replace(/\r|\n|\r\n/g, "");
 	var t1 = '${.data_model.input}';

--- a/webapp/WEB-INF/templates/admin/portlet/create_portlet.html
+++ b/webapp/WEB-INF/templates/admin/portlet/create_portlet.html
@@ -68,7 +68,7 @@
 		</@fieldSet>
 	</@tform>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function(){
 	$("#params").toggle();
 	$("#bt-toggle").click(function(){

--- a/webapp/WEB-INF/templates/admin/portlet/modify_portlet.html
+++ b/webapp/WEB-INF/templates/admin/portlet/modify_portlet.html
@@ -117,7 +117,7 @@
 		</@fieldSet>
 	</@tform>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function(){
 	$("legend").first().prepend('<a id="trigger" class="btn btn-flat btn-sm btn-info" href="#" title="#i18n{portal.site.portlet.labelShowHideProperties}"><i class="fa fa-chevron-left"></i></a>&#160;');
 	$("#trigger").click(function(){

--- a/webapp/WEB-INF/templates/admin/site/site_map.html
+++ b/webapp/WEB-INF/templates/admin/site/site_map.html
@@ -34,7 +34,7 @@
 
 <script src="js/admin/jquery/plugins/ui/jstree/jquery.cookie.js"></script>
 <script src="js/admin/jquery/plugins/ui/jstree/jquery.jstree.js"></script>
-<script type="text/javascript">
+<script>
 	$(function($) {
 		$("#btn-tree_search").click(function () {
 			$("#tree").jstree("search" ,	$("#tree_search").val()	);

--- a/webapp/WEB-INF/templates/admin/util/calendar/macro_datepicker.html
+++ b/webapp/WEB-INF/templates/admin/util/calendar/macro_datepicker.html
@@ -21,7 +21,7 @@
 <#macro getDatePickerBootstrap idField language >
 	<script src="js/admin/bootstrap-datepicker.js"></script>
 	<script src="js/admin/locales/bootstrap-datepicker.<@getRegional language=language />.js" charset="utf-8"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready( function() {
 		<#-- boostrap version -->
  		$('#${idField}').datepicker({language: '<@getRegional language=language />', autoclose: true});
@@ -32,7 +32,7 @@
 <#macro getDatePickerBootstrapClass idForm language >
 	<script src="js/admin/bootstrap-datepicker.min.js"></script>
 	<script src="js/admin/locales/bootstrap-datepicker.<@getRegional language=language />.js" charset="utf-8"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready( function() {
 		<#-- boostrap version -->
  		$("#${idForm} .dtBootstrap").datepicker({language: '<@getRegional language=language />', autoclose: true});
@@ -44,7 +44,7 @@
 <#macro getDatePicker idField language >
 	<script src="js/admin/jquery/plugins/ui/jquery-ui.min.js"></script>
 	<script src="js/admin/jquery/plugins/ui/ui.datepicker-fr.js"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready(function(){
 		$('#${idField}').datepicker({language: '<@getRegional language=language />'});
 	});
@@ -69,7 +69,7 @@
 <#macro getDatePickerRangeBootstrap language >
 	<script src="js/admin/bootstrap-datepicker.js"></script>
 	<script src="js/admin/locales/bootstrap-datepicker.<@getRegional language=language />.js" charset="utf-8"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready( function() {
 		<#-- The range must be defined with a <div class="input-daterange">..</div> englobing 2 input fields as shown beside.
 		Example:
@@ -94,7 +94,7 @@
 <#macro getDatePickerRange idFieldFrom idFieldTo language >
 	<script src="js/admin/jquery/plugins/ui/jquery-ui.min.js"></script>
 	<script src="js/admin/jquery/plugins/ui/ui.datepicker-fr.js"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready(function() {
 		<#-- <@setDefaultsDatePicker /> -->
 		$('#${idFieldFrom}').datepicker();

--- a/webapp/WEB-INF/templates/admin/util/calendar/macro_datepicker_materialkit.html
+++ b/webapp/WEB-INF/templates/admin/util/calendar/macro_datepicker_materialkit.html
@@ -183,7 +183,7 @@ Example:
 <#macro getDatePicker idField language >
 	<script src="js/admin/jquery/plugins/ui/jquery-ui.min.js"></script>
 	<script src="js/admin/jquery/plugins/ui/ui.datepicker-fr.js"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready(function(){
 		$('#${idField}').datepicker({language: '<@getRegional language=language />'});
 	});
@@ -205,7 +205,7 @@ Example:
 <#macro getDatePickerRange idFieldFrom idFieldTo language >
 	<script src="js/admin/jquery/plugins/ui/jquery-ui.min.js"></script>
 	<script src="js/admin/jquery/plugins/ui/ui.datepicker-fr.js"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready(function() {
 		<#-- <@setDefaultsDatePicker /> -->
 		$('#${idFieldFrom}').datepicker();

--- a/webapp/WEB-INF/templates/admin/util/calendar/macro_datetimepicker.html
+++ b/webapp/WEB-INF/templates/admin/util/calendar/macro_datetimepicker.html
@@ -1,7 +1,7 @@
 <#macro getDateTimePickerBootstrap idField language format='Y-m-d H:i:S' showFormat='d-m-Y H:i'>
 <script src="js/admin/bootstrap-flatpickr.min.js"></script>
 <script src="js/admin/locales/bootstrap-flatpickr.<@getRegional language=language />.js" charset="utf-8"></script>
-<script type="text/javascript" charset="utf-8">
+<script charset="utf-8">
 $( function() {
 	$('#${idField}').flatpickr({enableTime: true, <#if showFormat !=''>altInput:true, altFormat:'${showFormat}'</#if>, dateFormat: '${format}', "locale": "<@getRegional language=language />"});
 });
@@ -11,7 +11,7 @@ $( function() {
 <#macro getDateFlatPicker idField language format='d/m/Y'>
 <script src="js/admin/bootstrap-flatpickr.min.js"></script>
 <script src="js/admin/locales/bootstrap-flatpickr.<@getRegional language=language />.js" charset="utf-8"></script>
-<script type="text/javascript" charset="utf-8">
+<script charset="utf-8">
 $(  function() {
 	$('#${idField}').flatpickr({enableTime: false, dateFormat: '${format}', "locale": "<@getRegional language=language />"});
 });
@@ -21,7 +21,7 @@ $(  function() {
 <#macro getDateRangeFlatPicker idField language format='d/m/Y'>
 <script src="js/admin/bootstrap-flatpickr.min.js"></script>
 <script src="js/admin/locales/bootstrap-flatpickr.<@getRegional language=language />.js" charset="utf-8"></script>
-<script type="text/javascript" charset="utf-8">
+<script charset="utf-8">
 $(  function() {
 	$('#${idField}').flatpickr({enableTime: false, dateFormat: '${format}', "locale": "<@getRegional language=language />", mode: "range"});
 });
@@ -31,7 +31,7 @@ $(  function() {
 <#macro getDateTimeRangeFlatPicker idField language format='d/m/Y H:i'>
 <script src="js/admin/bootstrap-flatpickr.min.js"></script>
 <script src="js/admin/locales/bootstrap-flatpickr.<@getRegional language=language />.js" charset="utf-8"></script>
-<script type="text/javascript" charset="utf-8">
+<script charset="utf-8">
 $(  function() {
 	$('#${idField}').flatpickr({enableTime: true, dateFormat: '${format}', "locale": "<@getRegional language=language />", mode: "range"});
 });

--- a/webapp/WEB-INF/templates/admin/util/editor/editor_tinymce.html
+++ b/webapp/WEB-INF/templates/admin/util/editor/editor_tinymce.html
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="${webapp_url!}js/admin/editors/tinymce/tinymce.min.js"></script>
+<script src="${webapp_url!}js/admin/editors/tinymce/tinymce.min.js"></script>
 <#macro initEditor editorWidth=450 cssFiles="" type=''>
 <#assign editorLocale="" />
 <#-- We only have the language pack for French (France) installed in webapp/js/editors/tinymce/langs -->
@@ -10,7 +10,7 @@
 <#if cssFiles=="">
 	<#assign cssFiles="editor.css, page_template_styles.css" />
 </#if>
-<script type="text/javascript">
+<script>
   <#if type == 'inlite'>
 	tinymce.init({
 		selector: 'div.richtext',

--- a/webapp/WEB-INF/templates/commons.html
+++ b/webapp/WEB-INF/templates/commons.html
@@ -977,7 +977,7 @@
 			<#if style?contains('collapse')>
 				<#local widgetAction = 'collapse' />
 				<div style="display:none;">
-					<script type="text/javascript">
+					<script>
 						$(document).ready(function() {
 							<#if buttonIcon = 'minus'>
 							$("${buttonTargetId}").addClass("collapse in");

--- a/webapp/WEB-INF/templates/commons_bs4_adminlte.html
+++ b/webapp/WEB-INF/templates/commons_bs4_adminlte.html
@@ -960,7 +960,7 @@
 			<#if style?contains('collapse')>
 				<#local widgetAction = 'collapse' />
 				<div style="display:none;">
-					<script type="text/javascript">
+					<script>
 						$(document).ready(function() {
 							<#if buttonIcon = 'minus'>
 							$("${buttonTargetId}").addClass("show");

--- a/webapp/WEB-INF/templates/commons_bs4_materialkit.html
+++ b/webapp/WEB-INF/templates/commons_bs4_materialkit.html
@@ -522,7 +522,7 @@
 		</#if>
 		<input class="<#if type='file'>inputFileHidden<#else>form-control</#if><#if size!=''> form-control-${size}</#if><#if class!=''> ${class}</#if>" name="${name}" type="${type}" value="${value}"<#if tabIndex!=''> tabindex="${tabIndex}"</#if><#if placeHolder!=''> placeholder="${placeHolder}<#if mandatory> [#i18n{portal.users.modify_attribute.labelMandatory}]</#if>"</#if><#if title!=''> title="${title}"</#if><#if maxlength &gt; 0> maxlength="${maxlength}"</#if><#if inputSize!=0> size="${inputSize}"</#if><#if disabled> disabled</#if><#if readonly> readonly</#if><#if id!=''> id="${id}"</#if><#if params!=''> ${params}</#if><#if pattern!=''>pattern=${pattern}</#if><#if min!=max> min="${min}"</#if><#if max!=0> max="${max}"</#if><#if mandatory> required</#if><#if labelFor?? && labelFor!='' && helpKey?? && helpKey!=''> aria-describedby="${labelFor}_help"</#if> />
 		<#if type='file'>
-		<script type="text/javascript">
+		<script>
 			$(".inputFileHidden").parents('div.form-group').addClass('form-file-upload form-file-simple');
 		</script>
 		</#if>
@@ -551,7 +551,7 @@
 <p class="<#if inForm>form-control-plaintext</#if><#if color!=''> text-${color}</#if>"<#if id!=''> id="${id}"</#if><#if params!=''> ${params}</#if>>
 	<#nested>
 </p>
-<script type="text/javascript">
+<script>
 $('.form-control-plaintext').parents('div.form-group').addClass('is-filled');
 </script>
 </#macro>
@@ -597,7 +597,7 @@ $('.form-control-plaintext').parents('div.form-group').addClass('is-filled');
 		<#nested>
 	</#if>
 	</select>
-	<script type="text/javascript">
+	<script>
 		$("select").parents('div.form-group').addClass('is-filled');
 	</script>
 </#macro>
@@ -621,7 +621,7 @@ $('.form-control-plaintext').parents('div.form-group').addClass('is-filled');
 		</span>
 	</label>
 </div>
-	<script type="text/javascript">
+	<script>
 		$(".form-check").parents('div.form-group').find('label').removeClass('bmd-label-floating');
 	</script>
 </#macro>
@@ -643,7 +643,7 @@ $('.form-control-plaintext').parents('div.form-group').addClass('is-filled');
 			</span>
 			</label>
 </div>
-	<script type="text/javascript">
+	<script>
 		$(".form-check").parents('div.form-group').addClass('is-filled');
 	</script>
 </#macro>
@@ -655,7 +655,7 @@ $('.form-control-plaintext').parents('div.form-group').addClass('is-filled');
 	<div class="input-group<#if size!=''> input-group-${size}</#if><#if class!=''> ${class}</#if>" <#if id!=''> id="${id}"</#if><#if params!=''> ${params}</#if>>
 		<#nested>
 	</div>
-		<script type="text/javascript">
+		<script>
 			$(".input-group").parent().prev("label.bmd-label-floating").addClass('bmd-label-static').removeClass("bmd-label-floating");
 		</script>
 </#macro>
@@ -1000,7 +1000,7 @@ $('.form-control-plaintext').parents('div.form-group').addClass('is-filled');
 			<#if style?contains('collapse')>
 				<#local widgetAction = 'collapse' />
 				<div style="display:none;">
-					<script type="text/javascript">
+					<script>
 						$(document).ready(function() {
 							<#if buttonIcon = 'minus'>
 							$("${buttonTargetId}").addClass("show");

--- a/webapp/WEB-INF/templates/commons_bulma.html
+++ b/webapp/WEB-INF/templates/commons_bulma.html
@@ -1140,7 +1140,7 @@ and is kept only for backwards compatibility
 	<#assign parentId = id>
 	<#nested>
 </div>
-<script type='text/javascript'>
+<script>
     var accordions = bulmaAccordion.attach();     
 </script>
 </#macro>
@@ -1274,7 +1274,7 @@ and is kept only for backwards compatibility
 		<#if style?contains('collapse')>
 			<#local widgetAction = 'collapse' />
 			<div style="display:none;">
-				<script type="text/javascript">
+				<script>
 					$(document).ready(function() {
 						<#if buttonIcon = 'minus'>
 						$("${buttonTargetId}").addClass("collapse in");

--- a/webapp/WEB-INF/templates/skin/site/plugin_javascript_link.html
+++ b/webapp/WEB-INF/templates/skin/site/plugin_javascript_link.html
@@ -1,1 +1,1 @@
-<script src="${plugin_javascript_file}" type="text/javascript" ></script>
+<script src="${plugin_javascript_file}"></script>

--- a/webapp/WEB-INF/templates/util/calendar/macro_datepicker.html
+++ b/webapp/WEB-INF/templates/util/calendar/macro_datepicker.html
@@ -21,7 +21,7 @@
 <#macro getDatePickerBootstrap idField language >
 	<script src="js/bootstrap-datepicker.js"></script>
 	<script src="js/locales/bootstrap-datepicker.<@getRegional language=language />.js" charset="utf-8"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready( function() {
 		<#-- boostrap version -->
  		$('#${idField}').datepicker({language: '<@getRegional language=language />', autoclose: true});
@@ -32,7 +32,7 @@
 <#macro getDatePickerBootstrapClass idForm language >
 	<script src="js/bootstrap-datepicker.min.js"></script>
 	<script src="js/locales/bootstrap-datepicker.<@getRegional language=language />.js" charset="utf-8"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready( function() {
 		<#-- boostrap version -->
  		$("#${idForm} .dtBootstrap").datepicker({language: '<@getRegional language=language />', autoclose: true});
@@ -44,7 +44,7 @@
 <#macro getDatePicker idField language >
 	<script src="js/jquery/plugins/ui/jquery-ui.min.js"></script>
 	<script src="js/jquery/plugins/ui/ui.datepicker-fr.js"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready(function(){
 		$('#${idField}').datepicker({language: '<@getRegional language=language />'});
 	});
@@ -69,7 +69,7 @@
 <#macro getDatePickerRangeBootstrap language >
 	<script src="js/bootstrap-datepicker.js"></script>
 	<script src="js/locales/bootstrap-datepicker.<@getRegional language=language />.js" charset="utf-8"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready( function() {
 		<#-- The range must be defined with a <div class="input-daterange">..</div> englobing 2 input fields as shown beside.
 		Example:
@@ -94,7 +94,7 @@
 <#macro getDatePickerRange idFieldFrom idFieldTo language >
 	<script src="js/jquery/plugins/ui/jquery-ui.min.js"></script>
 	<script src="js/jquery/plugins/ui/ui.datepicker-fr.js"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready(function() {
 		<#-- <@setDefaultsDatePicker /> -->
 		$('#${idFieldFrom}').datepicker();

--- a/webapp/WEB-INF/templates/util/calendar/macro_datetimepicker.html
+++ b/webapp/WEB-INF/templates/util/calendar/macro_datetimepicker.html
@@ -1,7 +1,7 @@
 <#macro getDateTimePickerBootstrap idField language >
 	<script src="js/admin/bootstrap-flatpickr.min.js"></script>
 	<script src="js/admin/locales/bootstrap-flatpickr.<@getRegional language=language />.js" charset="utf-8"></script>
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 	$(document).ready( function() {
  		$('#${idField}').flatpickr({enableTime: true, dateFormat: 'Y-m-d H:i:S', "locale": "<@getRegional language=language />"});
 	});

--- a/webapp/WEB-INF/templates/util/editor/editor_markitupbbcode.html
+++ b/webapp/WEB-INF/templates/util/editor/editor_markitupbbcode.html
@@ -2,11 +2,11 @@
 <#macro initEditor skin="simple" emo="true" teditor="true">
 <!-- Load up the actual editor core -->
 <!-- markItUp! -->
-<script type="text/javascript" src="js/editors/markitup/jquery.markitup.js"></script>
+<script src="js/editors/markitup/jquery.markitup.js"></script>
 <!-- markItUp! toolbar settings -->
-<script type="text/javascript" src="js/editors/markitup/sets/bbcode/set.js"></script>
+<script src="js/editors/markitup/sets/bbcode/set.js"></script>
 <!-- markItUp! Init -->
-<script type="text/javascript">
+<script>
 $(document).ready(function(){
 	
 	<!-- markItUp! add css head skin -->

--- a/webapp/WEB-INF/xsl/normal/menu_tree.xsl
+++ b/webapp/WEB-INF/xsl/normal/menu_tree.xsl
@@ -6,7 +6,7 @@
     <xsl:template match="menu-list">
         <xsl:variable name="menu-list" select="menu" />
 
-        <script type="text/javascript">
+        <script>
             $(document).ready(function(){
             $("#tree").treeview({
                 animated: "fast",


### PR DESCRIPTION
The HTML spec says for the type attribute of the script tag:
Omitting the attribute, setting it to the empty string, or setting it to a JavaScript MIME type essence match,
means that the script is a classic script, to be interpreted according to the JavaScript Script top-level
production. Classic scripts are affected by the async and defer attributes, but only when the src attribute
is set. Authors should omit the type attribute instead of redundantly setting it.

text/javascript is a JavaScript MIME type essence match, therefore type="text/javascript" should be omitted.

This has also the merit of suppressing a warning when validating the HTML produced by Lutece