### PR TITLE
LUTECE-2354: Remove default role form on form tag

### DIFF
--- a/webapp/WEB-INF/templates/commons.html
+++ b/webapp/WEB-INF/templates/commons.html
@@ -471,7 +471,7 @@
 <#-- FORM -->
 <#-- type: inline/horizontal/form -->
 <#-- enctype: multipart/form-data | text/plain -->
-<#macro tform type='horizontal' class='' align='' hide=[] action='' method='post' name='' id='' role='form' collapsed=false enctype='' params='' deprecated...>
+<#macro tform type='horizontal' class='' align='' hide=[] action='' method='post' name='' id='' role='' collapsed=false enctype='' params='' deprecated...>
 <@deprecatedWarning args=deprecated />	
 <#local class = class />
 <#if align!=''><#local class += ' ' + alignmentSettings(align,'') /></#if>

--- a/webapp/WEB-INF/templates/commons_bs4_adminlte.html
+++ b/webapp/WEB-INF/templates/commons_bs4_adminlte.html
@@ -402,7 +402,7 @@
 <#-- FORM -->
 <#-- type: inline/horizontal/form -->
 <#-- enctype: multipart/form-data | text/plain -->
-<#macro tform type='horizontal' class='' align='' hide=[] action='' method='post' name='' id='' role='form' collapsed=false enctype='' params='' deprecated...>
+<#macro tform type='horizontal' class='' align='' hide=[] action='' method='post' name='' id='' role='' collapsed=false enctype='' params='' deprecated...>
 	<@deprecatedWarning args=deprecated />	
 	<#local class = class />
 	<#if align!=''><#local class += ' ' + alignmentSettings(align,'') /></#if>

--- a/webapp/WEB-INF/templates/commons_bs4_materialkit.html
+++ b/webapp/WEB-INF/templates/commons_bs4_materialkit.html
@@ -415,7 +415,7 @@
 <#-- FORM -->
 <#-- type: inline/horizontal/form -->
 <#-- enctype: multipart/form-data | text/plain -->
-<#macro tform type='horizontal' class='' align='' hide=[] action='' method='post' name='' id='' role='form' collapsed=false enctype='' params='' deprecated...>
+<#macro tform type='horizontal' class='' align='' hide=[] action='' method='post' name='' id='' role='' collapsed=false enctype='' params='' deprecated...>
 	<@deprecatedWarning args=deprecated />
 	<#local class = class />
 	<#if align!=''><#local class += ' ' + alignmentSettings(align,'') /></#if>

--- a/webapp/WEB-INF/templates/commons_bulma.html
+++ b/webapp/WEB-INF/templates/commons_bulma.html
@@ -841,7 +841,7 @@ and is kept only for backwards compatibility
 <#-- FORM -->
 <#-- type: inline/horizontal/form -->
 <#-- enctype: multipart/form-data | text/plain -->
-<#macro tform type='horizontal' class='' align='' hide=[] action='' method='post' name='' id='' role='form' collapsed=false enctype='' params='' deprecated...>
+<#macro tform type='horizontal' class='' align='' hide=[] action='' method='post' name='' id='' role='' collapsed=false enctype='' params='' deprecated...>
 	<@deprecatedWarning args=deprecated />	
 	<#local class = class />
 	<#if align!=''><#local class += ' ' + alignmentSettings(align) /></#if>

--- a/webapp/themes/commons.html
+++ b/webapp/themes/commons.html
@@ -730,7 +730,7 @@ and is kept only for backwards compatibility
 
 <#-- FORM -->
 <#-- class: form-inline/form-horizontal/navbar-form/navbar-left/search-form... Default is horizontal -->
-<#macro tform class='form-horizontal' class2='' action='' method='post' name='' id='' role='form' params=''>
+<#macro tform class='form-horizontal' class2='' action='' method='post' name='' id='' role='' params=''>
 	<form class="${class}<#if class2!=''> ${class2}</#if>"<#if id!=''> id="${id}"</#if><#if action!=''> action="${action}"</#if><#if method!=''> method="${method}"</#if><#if name!=''> name="${name}"</#if><#if role!=''> role="${role}"</#if><#if params!=''> ${params}</#if>>
 		<#nested>
 	</form>


### PR DESCRIPTION
The ARIA spec says: WAI-ARIA is designed to provide semantic information about
objects when host languages lack native semantics for the object. (...) For
example, if an element with the functionality already exists, such as a checkbox
or radio button, use the native semantics of the host language. WAI-ARIA markup
is only intended to be used to enhance the native semantics (e.g., indicating
that the element is required with aria-required), or to change the semantics to
a different purpose from the standard functionality of the element.

the form tag implies the form role, and therefore should be omitted unless justified

This has the added benefit of removing a warning when validating the HTML produced by Lutece