### PR TITLE
LUTECE-2355: Only add id attribute to table if not empty

### DIFF
--- a/webapp/WEB-INF/templates/commons.html
+++ b/webapp/WEB-INF/templates/commons.html
@@ -306,7 +306,7 @@
 <#if bordered>  <#local class += ' table-bordered'  /> </#if>
 <#if collapsed> <#local class += ' collapse' /> </#if>
 <#if responsive><div class="table-responsive"></#if>
-<table class="table ${class?trim}" id="${id}"<#if params!=''> ${params}</#if>>
+<table class="table ${class?trim}" <#if id!=''> id="${id}"</#if><#if params!=''> ${params}</#if>>
 <#if caption!=''><caption>${caption}</caption></#if>
 <#if headBody><thead></#if>
 	<#nested>

--- a/webapp/WEB-INF/templates/commons_bs4_adminlte.html
+++ b/webapp/WEB-INF/templates/commons_bs4_adminlte.html
@@ -273,7 +273,7 @@
 	<#if responsive>
 	<div class="table-responsive-sm">
 	</#if>
-	<table class="table ${class?trim}" id="${id}"<#if params!=''> ${params}</#if>>
+	<table class="table ${class?trim}" <#if id!=''> id="${id}"</#if><#if params!=''> ${params}</#if>>
 		<#nested>
 	</table>
 	<#if responsive>

--- a/webapp/WEB-INF/templates/commons_bs4_materialkit.html
+++ b/webapp/WEB-INF/templates/commons_bs4_materialkit.html
@@ -284,7 +284,7 @@
 	<#if responsive>
 	<div class="table-responsive">
 	</#if>
-	<table class="table ${class?trim}" id="${id}"<#if params!=''> ${params}</#if>>
+	<table class="table ${class?trim}" <#if id!=''> id="${id}"</#if><#if params!=''> ${params}</#if>>
 		<#nested>
 	</table>
 	<#if responsive>

--- a/webapp/WEB-INF/templates/commons_bulma.html
+++ b/webapp/WEB-INF/templates/commons_bulma.html
@@ -685,7 +685,7 @@ and is kept only for backwards compatibility
     <#if bordered>  <#local class += ' is-bordered'  /> </#if>
 	<#if collapsed> <#local class += ' collapse' /> </#if>
     
-    <table class="table is-fullwidth ${class?trim}" id="${id}"<#if params!=''> ${params}</#if>>
+    <table class="table is-fullwidth ${class?trim}" <#if id!=''> id="${id}"</#if><#if params!=''> ${params}</#if>>
         <#nested>
     </table>
 </#macro>

--- a/webapp/themes/commons.html
+++ b/webapp/themes/commons.html
@@ -681,7 +681,7 @@ and is kept only for backwards compatibility
 	<#if responsive>
 	<div class="table-responsive">
 	</#if>
-		<table class="table table-hover table-condensed<#if class!=''> ${class}</#if>" id="${id}"<#if params!=''> ${params}</#if>>
+		<table class="table table-hover table-condensed<#if class!=''> ${class}</#if>" <#if id!=''> id="${id}"</#if><#if params!=''> ${params}</#if>>
 			<#nested>
 		</table>
 	<#if responsive>


### PR DESCRIPTION
The HTML spec says: When specified on HTML elements, the id attribute value must
be unique amongst all the IDs in the element's tree and must contain at least
one character. The value must not contain any ASCII whitespace.

Thus if the id argument of the table macro is empty, the id attribute should
not be set.