### PR TITLE
LUTECE-2356: Add missing closing span to bulma's sort macro

### DIFF
--- a/webapp/WEB-INF/templates/commons_bulma.html
+++ b/webapp/WEB-INF/templates/commons_bulma.html
@@ -139,7 +139,7 @@
             <span class="icon"><i class="fa fa-chevron-up"></i></span>
 		</a>
 		<a class="button is-default is-small" href="${sort_url}false#sort${id!}_${attribute!}" title="#i18n{portal.util.sort.desc}">
-			<span class="icon"><i class="fa fa-chevron-down"></i>
+			<span class="icon"><i class="fa fa-chevron-down"></i></span>
 		</a>
 	</div>
 </#macro>


### PR DESCRIPTION
The HTML spec says for the span element :
Tag omission in text/html:Neither tag is omissible.