### PR TITLE
Redmine-24945: Upgrade PBKDF iterations count as per OWSAP recommandations

### DIFF
--- a/src/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactory.java
+++ b/src/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactory.java
@@ -140,11 +140,12 @@ final class PasswordFactory implements IPasswordFactory
             RANDOM = rand;
         }
 
-        private static final String PROPERTY_PASSWORD_HASH_ITERATIONS = "password.hash.iterations";
+        static final String PROPERTY_PASSWORD_HASH_ITERATIONS = "password.hash.iterations";
+        static final int DEFAULT_HASH_ITERATIONS = 40000;
         private static final String PROPERTY_PASSWORD_HASH_LENGTH = "password.hash.length";
 
         /** number of iterations */
-        private final int _iterations;
+        final int _iterations;
         /** salt */
         private final byte [ ] _salt;
         /** hashed password */
@@ -174,7 +175,7 @@ final class PasswordFactory implements IPasswordFactory
             switch( representation )
             {
                 case CLEARTEXT:
-                    _iterations = AppPropertiesService.getPropertyInt( PROPERTY_PASSWORD_HASH_ITERATIONS, 40000 );
+                    _iterations = AppPropertiesService.getPropertyInt( PROPERTY_PASSWORD_HASH_ITERATIONS, DEFAULT_HASH_ITERATIONS );
                     int hashLength = AppPropertiesService.getPropertyInt( PROPERTY_PASSWORD_HASH_LENGTH, 128 );
                     try
                     {
@@ -337,7 +338,8 @@ final class PasswordFactory implements IPasswordFactory
         @Override
         public boolean isLegacy( )
         {
-            return false;
+            int iterations = AppPropertiesService.getPropertyInt( PROPERTY_PASSWORD_HASH_ITERATIONS, DEFAULT_HASH_ITERATIONS );
+            return _iterations < iterations;
         }
 
         @Override

--- a/src/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactory.java
+++ b/src/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactory.java
@@ -141,7 +141,7 @@ final class PasswordFactory implements IPasswordFactory
         }
 
         static final String PROPERTY_PASSWORD_HASH_ITERATIONS = "password.hash.iterations";
-        static final int DEFAULT_HASH_ITERATIONS = 40000;
+        static final int DEFAULT_HASH_ITERATIONS = 210000;
         private static final String PROPERTY_PASSWORD_HASH_LENGTH = "password.hash.length";
 
         /** number of iterations */

--- a/src/test/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactoryTest.java
+++ b/src/test/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactoryTest.java
@@ -167,9 +167,9 @@ public class PasswordFactoryTest extends LuteceTestCase
     public void testGetPasswordPBKDF2WithHmacSHA512( )
     {
         PasswordFactory passwordFactory = new PasswordFactory( );
-        String storedPassword = "PBKDF2WITHHMACSHA512:40000:90be05c0b062cdc94fd6124a88f95523:4e574b19813e5e5af7ae936a1798b0c12f28b79bb761f32f94270b31"
-                + "731f44bca37513855af9c08f7abf09e65bc46f9f1b25d39b31a657b5649c7bc8020e1486ae854c5aefdb73a74e4ceb0acd96abee24ca68cf8c0403b7602952f0a0"
-                + "bf8662a4c83c4c28ecb0c282d2afe49e71870e260c07f419c9ddd3c63115694864b1e5";
+        String storedPassword = "PBKDF2WITHHMACSHA512:210000:f89603fe9d91a8e622a86a927ecf13db:95c00213d61d4b6b8d5200b578a9a5bdb8d70fbb249e6f956d7"
+                + "6c84af02c9c37260dee41e2ec8d7fb4c51b85f36025d729ce453fe169f9a688ebaf2efeb61a7934c419e76576d885411fd87a71408517952e56a33ad03f5a1"
+                + "b9cf33311cd6b4767b164fda39c4cb2f942f9d360cfcf1498dd850536dc8447e94cb815b888ae2a";
         IPassword password = passwordFactory.getPassword( storedPassword );
         assertEquals( true, password.check( "PASSWORD" ) );
         assertEquals( false, password.check( "BAR" ) );

--- a/src/test/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactoryTest.java
+++ b/src/test/java/fr/paris/lutece/portal/business/user/authentication/PasswordFactoryTest.java
@@ -152,6 +152,18 @@ public class PasswordFactoryTest extends LuteceTestCase
         }
     }
 
+    public void testGetPasswordPBKDF2WithHmacSHA512UpgradeIterations( )
+    {
+        PasswordFactory passwordFactory = new PasswordFactory( );
+        String storedPassword = "PBKDF2WITHHMACSHA512:30000:ac08c57a261dc5db09de2b689b0c55bf:96340dad8137a023c7888245c4221acf18bfaf9f69dfff4c34b"
+                + "0da4f8cc5b2a8959b0552312dd3dccff002ad765fc7bef6429c4dd3760ad68b53a0323d1464d41d74271b1f0fccd80e94b99b5e4323ffc67109d5917cccf5"
+                + "e74641cd7059e88671bd58ee40223fb2051968dea450cc9806546f98798c5b6ed3b3f5d44b51e03f";
+        IPassword password = passwordFactory.getPassword( storedPassword );
+        assertEquals( true, password.check( "PASSWORD" ) );
+        assertEquals( false, password.check( "BAR" ) );
+        assertTrue( "Password stored with less iterations than the default should be marked as legacy so that it is upgraded", password.isLegacy( ) );
+    }
+
     public void testGetPasswordPBKDF2WithHmacSHA512( )
     {
         PasswordFactory passwordFactory = new PasswordFactory( );

--- a/webapp/WEB-INF/conf/lutece.properties
+++ b/webapp/WEB-INF/conf/lutece.properties
@@ -210,7 +210,7 @@ randomPassword.size=16
 # Unless you know what you are doing and are willing to make password storage less secure,
 # you should only change this parameter to a greater value
 #
-#password.hash.iterations=40000
+#password.hash.iterations=210000
 
 # PBKDF2WithHmacSHA1 hash length
 #password.hash.length=128


### PR DESCRIPTION
OWASP recommands 210000 iteration for PBKDF2-HMAC-SHA512
(see https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2)

Password stored with less iterations are marked as legacy so that they are upgraded on next login