### PR TITLE
LUT-25913: Sort cache keys and use a more compact presentation

### DIFF
--- a/webapp/WEB-INF/templates/admin/system/cache_infos.html
+++ b/webapp/WEB-INF/templates/admin/system/cache_infos.html
@@ -6,7 +6,7 @@
 			<h2 class="h4">Configuration</h2>
 			<@pre>${service.infos}</@pre>
 			<h3>Keys</h3>
-			<#list service.keys as key ><@p>${key}</@p></#list>
+			<@ul><#list service.keys?sort as key ><@li>${key?html}</@li></#list></@ul>
 		</@div>
 	</#list>
 	</@pageColumn>


### PR DESCRIPTION
The list of keys is displayed as an HTML list, which is more compact. HTML escape cache keys as a precaution.