### PR TITLE
LUT-25914: If cache statistics are enabled, display them

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/cache/AbstractCacheableService.java
+++ b/src/java/fr/paris/lutece/portal/service/cache/AbstractCacheableService.java
@@ -39,6 +39,7 @@ import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheException;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
+import net.sf.ehcache.Statistics;
 import net.sf.ehcache.event.CacheEventListener;
 
 import java.util.ArrayList;
@@ -250,6 +251,35 @@ public abstract class AbstractCacheableService implements CacheableService, Cach
     public String getInfos( )
     {
         return CacheService.getInfos( _cache );
+    }
+
+    /**
+     * Get cache statistics.
+     * 
+     * The string representation is susceptible to change
+     * 
+     * @return a string representation of cache statistics
+     * 
+     * @since 7.0.10
+     */
+    public String getStatistics( )
+    {
+        if ( !( isCacheEnable( ) && _cache.getCacheConfiguration( ).getStatistics( ) ) )
+        {
+            return null;
+        }
+        Statistics stats = _cache.getStatistics( );
+        StringBuilder buidler = new StringBuilder( );
+        buidler.append( "name = " ).append( stats.getAssociatedCacheName( ) ).append( "\ncacheHits = " )
+                .append( stats.getCacheHits( ) ).append( "\nonDiskHits = " ).append( stats.getOnDiskHits( ) )
+                .append( "\noffHeapHits = " ).append( stats.getOffHeapHits( ) ).append( "\ninMemoryHits = " )
+                .append( stats.getInMemoryHits( ) ).append( "\nmisses = " ).append( stats.getCacheMisses( ) )
+                .append( "\nonDiskMisses = " ).append( stats.getOnDiskMisses( ) ).append( "\noffHeapMisses = " )
+                .append( stats.getOffHeapMisses( ) ).append( "\ninMemoryMisses = " )
+                .append( stats.getInMemoryMisses( ) ).append( "\nsize = " ).append( stats.getObjectCount( ) )
+                .append( "\naverageGetTime = " ).append( stats.getAverageGetTime( ) ).append( "\nevictionCount = " )
+                .append( stats.getEvictionCount( ) );
+        return buidler.toString( );
     }
 
     // CacheEventListener implementation

--- a/webapp/WEB-INF/templates/admin/system/cache_infos.html
+++ b/webapp/WEB-INF/templates/admin/system/cache_infos.html
@@ -5,6 +5,10 @@
 		<@div id="cache-infos">
 			<h2 class="h4">Configuration</h2>
 			<@pre>${service.infos}</@pre>
+			<#if service.statistics??>
+			<h3>Statistics</h3>
+			<@pre>${service.statistics?html}</@pre>
+			</#if>
 			<h3>Keys</h3>
 			<#list service.keys as key ><@p>${key}</@p></#list>
 		</@div>


### PR DESCRIPTION
Display a simple representation of statistics, equivalent to Statistics.toString()