### PR TITLE
Use HTTPS for lutece repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <repository>
             <id>lutece</id>
             <name>luteceRepository</name>
-            <url>http://dev.lutece.paris.fr/maven_repository</url>
+            <url>https://dev.lutece.paris.fr/nexus/content/groups/maven_repository/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
Using HTTPS allow to avoid issue with latest Maven version (see https://maven.apache.org/docs/3.8.1/release-notes.html).