### PR TITLE
LUT-27083: Updated the emails' headers to properly send a calendar invite

### DIFF
--- a/webapp/WEB-INF/conf/config.properties
+++ b/webapp/WEB-INF/conf/config.properties
@@ -61,7 +61,7 @@ mail.type.plain=text/plain;charset=
 mail.type.html=text/html;charset=
 mail.type.calendar=text/calendar;charset=
 mail.type.calendar.separator=;
-mail.type.calendar.create=method=CREATE
+mail.type.calendar.create=method=REQUEST
 mail.type.calendar.cancel=method=CANCEL
 
 #default value if the no-reply email not found in datastore

--- a/webapp/WEB-INF/templates/admin/system/config_properties.html
+++ b/webapp/WEB-INF/templates/admin/system/config_properties.html
@@ -64,7 +64,7 @@ mail.type.plain=text/plain;charset=
 mail.type.html=text/html;charset=
 mail.type.calendar=text/calendar;charset=
 mail.type.calendar.separator=;
-mail.type.calendar.create=method=CREATE
+mail.type.calendar.create=method=REQUEST
 mail.type.calendar.cancel=method=CANCEL
 
 #default value if the no-reply email not found in datastore


### PR DESCRIPTION
As per the ICalendar specifications (c.f. https://datatracker.ietf.org/doc/html/rfc2445#section-4.7.2):

- The value of the MIME message's `Content-Type` _method_ parameter must be the same as the value of the _method_ property used when building the calendar object

Currently, the value of the _method_ used when creating a new calendar invite is `REQUEST` (c.f. [ICalService class from the gru-module-workflow-appointment](https://github.com/lutece-secteur-public/gru-module-workflow-appointment/blob/db86c56304be9492f7e10f5bf408dae74e8161ce/src/java/fr/paris/lutece/plugins/workflow/modules/appointment/service/ICalService.java#L203)).

This commit will udpate the value of the MIME message's `Content-Type` _method_ parameter from `CREATE` to `REQUEST`, to match the calendar object's value.