### PR TITLE
LUT-27856 : Fix User Level for non-default authentication mode (such as WSSO)

### DIFF
--- a/src/java/fr/paris/lutece/portal/web/user/AdminUserJspBean.java
+++ b/src/java/fr/paris/lutece/portal/web/user/AdminUserJspBean.java
@@ -1003,6 +1003,10 @@ public class AdminUserJspBean extends AdminFeaturesPageJspBean
             user.setAccessibilityMode( strAccessibilityMode != null );
             user.setWorkgroupKey( strWorkgroupKey );
 
+            if ( isUserAuthorizedToChangeUserLevel( currentUser, userToModify ) ){
+                user.setUserLevel( Integer.parseInt(request.getParameter( PARAMETER_USER_LEVEL )) );
+            }
+
             String strError = AdminUserFieldService.checkUserFields( request, getLocale( ) );
 
             if ( strError != null )

--- a/webapp/WEB-INF/templates/admin/user/modify_user.html
+++ b/webapp/WEB-INF/templates/admin/user/modify_user.html
@@ -35,9 +35,13 @@
 					</@columns>
 					<@columns sm=colsm>
 						<@fieldSet legend='#i18n{portal.users.modify_user.labelAttributes}'>
-						<@formGroup labelKey='${i18n("portal.users.create_user.userLevelLabel")}' rows=2>
-							<@staticText>${level.name}</@staticText>
-						</@formGroup> 
+						<@formGroup labelKey='${i18n("portal.users.create_user.userLevelLabel")}' labelFor='user_level' rows=2>
+							<#if user_levels?has_content>
+								<@select name='user_level' default_value='${level.id!}' items=user_levels sort=true />
+							<#else>
+								<@staticText>${level.name}</@staticText>
+							</#if>
+						</@formGroup>
 						<@formGroup labelFor='workgroup_key' labelKey='${i18n("portal.role.create_role.labelWorkgroupKey")}' rows=2>
 							<@select name='workgroup_key' default_value='${user.workgroupKey!}' items=workgroup_key_list sort=true />
 						</@formGroup> 


### PR DESCRIPTION
https://dev.lutece.paris.fr/bugtracker/issues/27856

To help testers verify the changes made in this PR, follow these steps:

The bug is not reproducible in the normal case. To test this fix locally, modify the conditions to force the program into the "else" branch.

1. In `AdminUserJspBean.java`
2. At line 849 and line 959 (in the `doModifyAdminUser` and `getModifyAdminUser ` methods), change the conditions :
   From:
   ```if (AdminAuthenticationService.getInstance().isDefaultModuleUsed())```
   To:
   `if (!AdminAuthenticationService.getInstance().isDefaultModuleUsed())`
   
   These changes will force the program to enter the "else" part, allowing you to verify the correct handling of user updates for non-default authentication scenarios.
