### PR TITLE
LUT-27866 : fix regression link to 26829 (Object Value in InfoMarker)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
         <dependency>
             <groupId>fr.paris.lutece.plugins</groupId>
             <artifactId>library-workflow-core</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.4-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://dev.lutece.paris.fr/bugtracker/issues/27866