### PR TITLE
LUT-29083 : Adapt AppInitExtension to the new resources loading mecanism and unit tests

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/init/AppInitExtension.java
+++ b/src/java/fr/paris/lutece/portal/service/init/AppInitExtension.java
@@ -51,7 +51,7 @@ public class AppInitExtension implements Extension
 
     protected void initPropertiesServices( @Observes @Priority(value=1) final BeforeBeanDiscovery bd   )
     {
-    	if ( Files.notExists( Paths.get( AppPathService.getWebAppPath( ) + PATH_CONF ) ) )
+        if ( !Files.exists( Paths.get( AppPathService.getWebAppPath( ) + PATH_CONF ) ) )
         {
 	    	String _strResourcesDir = getClass().getResource( "/" ).toString( ).replaceFirst( "file:", "" )
 	                .replaceFirst( "test-classes", "lutece" )

--- a/src/java/fr/paris/lutece/portal/service/init/AppInitExtension.java
+++ b/src/java/fr/paris/lutece/portal/service/init/AppInitExtension.java
@@ -51,7 +51,7 @@ public class AppInitExtension implements Extension
 
     protected void initPropertiesServices( @Observes @Priority(value=1) final BeforeBeanDiscovery bd   )
     {
-        if ( !Files.exists( Paths.get( AppPathService.getWebAppPath( ) + PATH_CONF ) ) )
+        if ( !Files.isReadable( Paths.get( AppPathService.getWebAppPath( ) + PATH_CONF ) ) )
         {
 	    	String _strResourcesDir = getClass().getResource( "/" ).toString( ).replaceFirst( "file:", "" )
 	                .replaceFirst( "test-classes", "lutece" )


### PR DESCRIPTION
When units tests are executed from a plugin, the File.notExists method return false even if the resource is in a jar file and so is not available.