### PR TITLE
LUT-31354: Do not log the stacktrace when the size limit for an upload is exceeded

### DIFF
--- a/src/java/fr/paris/lutece/portal/web/upload/UploadFilter.java
+++ b/src/java/fr/paris/lutece/portal/web/upload/UploadFilter.java
@@ -156,7 +156,7 @@ public abstract class UploadFilter implements Filter
             }
             catch( SizeLimitExceededException e )
             {
-                AppLogService.error( e.getMessage( ), e );
+                AppLogService.error( "Size limit error for upload: {}", e.getMessage( ) );
 
                 Object [ ] args = {
                         getDisplaySize( )


### PR DESCRIPTION
The stacktrace does not add relevant information, and thus pollutes the log file.