### PR TITLE
LUT-31975: Add async-supported to web.xml filters for SSE streaming support

### DIFF
--- a/webapp/WEB-INF/web.xml
+++ b/webapp/WEB-INF/web.xml
@@ -31,6 +31,7 @@
     <filter>
         <filter-name>restApiSecurityHeaderFilter</filter-name>
         <filter-class>fr.paris.lutece.portal.service.filter.RestApiSecurityHeaderFilter</filter-class>
+        <async-supported>true</async-supported>
     </filter>
     <filter>
         <filter-name>encodingFilter</filter-name>
@@ -47,6 +48,7 @@
     <filter>
         <filter-name>pluginsFilters</filter-name>
         <filter-class>fr.paris.lutece.portal.service.filter.MainFilter</filter-class>
+        <async-supported>true</async-supported>
     </filter>
 
     <!-- This filter display error message in case of request parameters contains 


### PR DESCRIPTION
The filters restApiSecurityHeaderFilter and pluginsFilters declared in web.xml are missing the <async-supported>true</async-supported> attribute.

This prevents any module using JAX-RS Server-Sent Events (SSE) from working, as the servlet container refuses to switch the request to asynchronous mode. The error thrown is:
RESTEASY002186: Failed to set servlet request into asynchronous mode

The fix adds <async-supported>true</async-supported> to both filters.