### PR TITLE
LUT-32417: Provide a default pathlabel for XPage

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/content/XPageAppService.java
+++ b/src/java/fr/paris/lutece/portal/service/content/XPageAppService.java
@@ -52,6 +52,7 @@ import fr.paris.lutece.util.html.HtmlTemplate;
 import fr.paris.lutece.util.http.SecurityUtil;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import java.util.Collection;
@@ -247,7 +248,7 @@ public class XPageAppService extends ContentService
 
         data.setContent( page.getContent( ) );
         data.setName( page.getTitle( ) );
-        data.setPagePath( PortalService.getXPagePathContent( page.getPathLabel( ), 0, request ) );
+        data.setPagePath( PortalService.getXPagePathContent( ObjectUtils.getIfNull( page.getPathLabel( ), strName ), 0, request ) );
 
         return PortalService.buildPageContent( data, nMode, request );
     }

--- a/src/test/java/fr/paris/lutece/portal/service/portal/PortalServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/portal/PortalServiceTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import fr.paris.lutece.portal.business.page.Page;
+import fr.paris.lutece.portal.business.style.PageTemplateHome;
 import fr.paris.lutece.portal.service.cache.CacheService;
 import fr.paris.lutece.portal.service.cache.CacheableService;
 import fr.paris.lutece.portal.service.cache.IPathCacheService;
@@ -131,6 +132,7 @@ public class PortalServiceTest extends LuteceTestCase
         page.setName( "junit2" );
         page.setDescription( "junit2" );
         page.setParentPageId( PortalService.getRootPageId( ) );
+        page.setPageTemplateId( PageTemplateHome.getPageTemplatesList( ).get( 0 ).getId( ) );
         pageService.createPage( page );
         return page.getId( );
     }


### PR DESCRIPTION
The switch from XSL to freemarker for the page breadcrumb made the pathlabel mandatory for XPages. Provide a default pathlabel for XPages which do not set one.

Fixes XPageAppServiceTest.testEnabledState