### PR TITLE
LUT-31971 : Add message for expired session and fix redirection

### DIFF
--- a/src/java/fr/paris/lutece/portal/resources/users_messages.properties
+++ b/src/java/fr/paris/lutece/portal/resources/users_messages.properties
@@ -34,6 +34,7 @@ message.user.not.authenticated=Please authenticate yourself.
 message.user.new.session=Welcome to a new session.
 message.user.change.password=Your password is no longer valid. You must change it before you can continue.
 message.user.authentication.failure=Access denied.
+message.user.session.expired=Your session has expired or has been lost. Please sign in again.
 message.user.disabled=This account has been disabled. Please contact an administrator.
 message.confirmRemoveUser=Are you sure you want to delete the user {0} {1} ({2})?
 message.user.accessCodeAlreadyUsed=This code is already assigned to another user.

--- a/src/java/fr/paris/lutece/portal/resources/users_messages_fr.properties
+++ b/src/java/fr/paris/lutece/portal/resources/users_messages_fr.properties
@@ -36,6 +36,7 @@ message.user.not.authenticated=Veuillez vous authentifier.
 message.user.new.session=Bienvenue dans une nouvelle session.
 message.user.change.password=Votre mot de passe n'est plus valide. Vous devez le changer avant de pouvoir continuer.
 message.user.authentication.failure=Acc\u00e8s refus\u00e9.
+message.user.session.expired=Votre session a expir\u00e9 ou a \u00e9t\u00e9 perdue. Veuillez vous reconnecter.
 message.user.disabled=Ce compte a \u00e9t\u00e9 d\u00e9sactiv\u00e9. Merci de contacter un administrateur.
 message.confirmRemoveUser=\u00cates-vous s\u00fbr de vouloir supprimer l''utilisateur {0} {1} ({2}) ?
 message.user.accessCodeAlreadyUsed=Ce code est d\u00e9j\u00e0 attribu\u00e9 \u00e0 un autre utilisateur.

--- a/src/java/fr/paris/lutece/portal/service/admin/AdminAuthenticationService.java
+++ b/src/java/fr/paris/lutece/portal/service/admin/AdminAuthenticationService.java
@@ -318,7 +318,9 @@ public final class AdminAuthenticationService
      */
     public AdminUser getRegisteredUser( HttpServletRequest request )
     {
-        HttpSession session = request.getSession( );
+        // Parametre a false pour ne pas recrér de nouvelle session,
+        // le but ici est juste de récupérer la session en cours
+        HttpSession session = request.getSession(false);
 
         if ( session != null )
         {

--- a/src/java/fr/paris/lutece/portal/web/constants/Messages.java
+++ b/src/java/fr/paris/lutece/portal/web/constants/Messages.java
@@ -48,6 +48,7 @@ public final class Messages
     public static final String MESSAGE_USER_DISABLED = "portal.users.message.user.disabled";
     public static final String MESSAGE_AUTH_FAILURE = "portal.users.message.user.authentication.failure";
     public static final String MESSAGE_USER_NOT_AUTHENTICATED = "portal.users.message.user.not.authenticated";
+    public static final String MESSAGE_USER_SESSION_EXPIRED = "portal.users.message.user.session.expired";
     public static final String MESSAGE_USER_NEW_SESSION = "portal.users.message.user.new.session";
     public static final String MESSAGE_USER_MUST_CHANGE_PASSWORD = "portal.users.message.user.change.password";
     public static final String MESSAGE_ERROR_SESSION = "portal.users.message.user.error.session";

--- a/src/java/fr/paris/lutece/portal/web/user/AuthenticationFilter.java
+++ b/src/java/fr/paris/lutece/portal/web/user/AuthenticationFilter.java
@@ -125,7 +125,12 @@ public class AuthenticationFilter implements Filter
             }
             catch( UserNotSignedException e )
             {
-                AdminAuthenticationService.getInstance( ).setLoginNextUrl( req );
+                boolean bSessionExpired = isRequestedSessionExpired( req );
+
+                if ( !bSessionExpired )
+                {
+                    AdminAuthenticationService.getInstance( ).setLoginNextUrl( req );
+                }
 
                 String strRedirectUrl = null;
 
@@ -140,7 +145,9 @@ public class AuthenticationFilter implements Filter
                 {
                     AppLogService.debug( "Access NOT granted to url : {}", ( ) -> getResquestedUrl( req ) );
 
-                    strRedirectUrl = AdminMessageService.getMessageUrl( req, Messages.MESSAGE_USER_NOT_AUTHENTICATED, getRedirectUrl( req ),
+                    String strMessage = bSessionExpired ? Messages.MESSAGE_USER_SESSION_EXPIRED : Messages.MESSAGE_USER_NOT_AUTHENTICATED;
+
+                    strRedirectUrl = AdminMessageService.getMessageUrl( req, strMessage, getRedirectUrl( req ),
                             AdminMessage.TYPE_WARNING );
                 }
 
@@ -175,6 +182,18 @@ public class AuthenticationFilter implements Filter
         }
 
         chain.doFilter( request, response );
+    }
+
+    /**
+     * Checks whether the browser sent a session id that is no longer valid on the server.
+     *
+     * @param request
+     *            the http request
+     * @return true if the requested session has expired or has been invalidated
+     */
+    private boolean isRequestedSessionExpired( HttpServletRequest request )
+    {
+        return request.getRequestedSessionId( ) != null && !request.isRequestedSessionIdValid( );
     }
 
     /**

--- a/webapp/jsp/admin/ErrorPage.jsp
+++ b/webapp/jsp/admin/ErrorPage.jsp
@@ -7,7 +7,7 @@
 <%@ page import="fr.paris.lutece.portal.service.message.AdminMessageService" %>
 <%@ page import="fr.paris.lutece.portal.service.message.AdminMessage" %>
 <%@ page import="fr.paris.lutece.portal.service.i18n.I18nService" %>
-
+<%@ page import="org.apache.commons.lang3.StringUtils" %>
 
 
 <%@ page buffer="1024kb"%>
@@ -43,8 +43,13 @@
     	}
         if ( AdminAuthenticationService.getInstance( ).getRegisteredUser( request ) == null )
         {
+			String strLoginUrl = AdminAuthenticationService.getInstance( ).getLoginPageUrl( );
+			if ( StringUtils.isBlank( strLoginUrl ) )
+			{
+				strLoginUrl =  AppPathService.getAdminMenuUrl( );
+			}
             response.sendRedirect( AdminMessageService.getMessageUrl( request, Messages.MESSAGE_USER_SESSION_EXPIRED,
-                    AdminAuthenticationService.getInstance( ).getLoginPageUrl( ), AdminMessage.TYPE_WARNING ) );
+					strLoginUrl, AdminMessage.TYPE_WARNING ) );
         }
         else
         {

--- a/webapp/jsp/admin/ErrorPage.jsp
+++ b/webapp/jsp/admin/ErrorPage.jsp
@@ -2,6 +2,7 @@
 <%@page import="fr.paris.lutece.portal.service.admin.PasswordResetException"%>
 <%@ page isErrorPage="true" %>
 <%@ page import="fr.paris.lutece.portal.web.constants.Messages" %>
+<%@ page import="fr.paris.lutece.portal.service.admin.AdminAuthenticationService" %>
 <%@ page import="fr.paris.lutece.portal.service.util.*" %>
 <%@ page import="fr.paris.lutece.portal.service.message.AdminMessageService" %>
 <%@ page import="fr.paris.lutece.portal.service.message.AdminMessage" %>
@@ -40,7 +41,15 @@
     	{
     		AppLogService.error( "AccessDeniedException : " + exception.getMessage() );
     	}
-        response.sendRedirect( AdminMessageService.getMessageUrl( request , Messages.USER_ACCESS_DENIED , AdminMessage.TYPE_STOP ) );
+        if ( AdminAuthenticationService.getInstance( ).getRegisteredUser( request ) == null )
+        {
+            response.sendRedirect( AdminMessageService.getMessageUrl( request, Messages.MESSAGE_USER_SESSION_EXPIRED,
+                    AdminAuthenticationService.getInstance( ).getLoginPageUrl( ), AdminMessage.TYPE_WARNING ) );
+        }
+        else
+        {
+            response.sendRedirect( AdminMessageService.getMessageUrl( request , Messages.USER_ACCESS_DENIED , AdminMessage.TYPE_STOP ) );
+        }
     }
     else if ( exception instanceof fr.paris.lutece.portal.service.admin.PasswordResetException )
     {


### PR DESCRIPTION
**getRegisteredUser** : On ne créé plus de nouvelle session quand on check la session d'un user (si celle ci n'est plus valide) car ça brise la logique de creation/delete de session de manière général.  create session est géré par exemple par registerUser

**AuthenticationFilter.java** : Ajout d'un test si la session est expiré, si oui on insert un message aproprié ET on ne set pas de setLoginNextUrl pour ne pas rediriger vers la page de travail précédente mais vers la page AdminMenu (celle par defaut)

**ErrorPage.jsp**  : Affiche une erreur pour la perte de connexion et redirection vers la page de connexion