### PR TITLE
LUT-32702 : Register cEmpty macro and fix card-body opening tag

### DIFF
--- a/webapp/WEB-INF/templates/skin/themes/macros/components/empty/cEmpty.ftl
+++ b/webapp/WEB-INF/templates/skin/themes/macros/components/empty/cEmpty.ftl
@@ -48,7 +48,7 @@ Snippet:
 <#else>
 	<div class="card-img<#if imgClass!=''> ${imgClass}</#if>"><img src="${img}" height="128" alt=""></div>
 </#if>
-    div class="card-body">
+    <div class="card-body">
 	<p class="card-title"><#if title=''>#i18n{portal.util.message.emptyTitle}	<#else>${title}</#if></p>
 <#if subtitle !=''>
 	<p class="card-subtitle text-muted">${subtitle}</p>

--- a/webapp/WEB-INF/templates/skin/themes/theme_commons_macros.ftl
+++ b/webapp/WEB-INF/templates/skin/themes/theme_commons_macros.ftl
@@ -17,6 +17,7 @@
 <@cMacro name='getThemeDatePicker' group='components/datepicker' />
 <@cMacro name='initThemeDatePicker' group='components/datepicker' />
 <@cMacro name='cDropdown' group='components/dropdown' />
+<@cMacro name='cEmpty' group='components/empty' />
 <@cMacro name='cErrorMessage' group='components/error' />
 <@cMacro name='cFilter' group='components/filter' />
 <@cMacro name='cIcon' group='components/icons' />


### PR DESCRIPTION
The cEmpty macro added in LUT-32702 was not registered in theme_commons_macros.ftl, so it was never loaded and `@cEmpty` failed with InvalidReferenceException. Also fixes a typo in cEmpty.ftl where the card-body div was missing its opening `<`.

- Register `cEmpty` (group components/empty) in theme_commons_macros.ftl
- Fix `div class="card-body">` -> `<div class="card-body">` in cEmpty.ftl