### PR TITLE
LUT-32709 : Fix cInput number macro render crash and exclusive bounds rejecting the min value

### DIFF
--- a/webapp/WEB-INF/templates/skin/themes/macros/forms/inputs/cInput.ftl
+++ b/webapp/WEB-INF/templates/skin/themes/macros/forms/inputs/cInput.ftl
@@ -95,13 +95,13 @@ function setInvalidMaxMinMessage( input ) {
   const value = parseFloat(input.value);
   const min = input.hasAttribute('min') ? parseFloat(input.getAttribute('min')) : -Infinity;
   const max = input.hasAttribute('max') ? parseFloat(input.getAttribute('max')) : Infinity;
-  if ( value <= min || value >= max  ) {
+  if ( value < min || value > max  ) {
     if ( !input.classList.contains('is-invalid') ) {
         input.classList.add('is-invalid');
         if( input.parentNode.classList.contains('input-group') ) {
-            input.parentNode.insertAdjacentHTML('beforebegin', '<p class="invalid-feedback" >${i18n('portal.theme.labelQuantityInvalid',input.min,input.max)}</p>' );
+            input.parentNode.insertAdjacentHTML('beforebegin', '<p class="invalid-feedback" >${i18n('portal.theme.labelQuantityInvalid',min,max)}</p>' );
         } else {
-            input.insertAdjacentHTML('beforebegin', '<p class="invalid-feedback" >${i18n('portal.theme.labelQuantityInvalid',input.min,input.max)}</p>' );
+            input.insertAdjacentHTML('beforebegin', '<p class="invalid-feedback" >${i18n('portal.theme.labelQuantityInvalid',min,max)}</p>' );
         }
         input.setAttribute('aria-invalid', 'true');
         input.setAttribute('aria-describedby', 'error_' + input.id);


### PR DESCRIPTION
Fixes Redmine [#32709](https://dev.lutece.paris.fr/bugtracker/issues/32709).

The number cInput macro crashed at render (NonHashException, `input` resolved as a macro inside `${i18n(...)}`) and its client validation used exclusive bounds (`<= min || >= max`), rejecting the boundary value (e.g. `min=1` rejected 1). Uses the macro min/max params and inclusive bounds.