### PR TITLE
LUT-32710 : Fix datetimepicker getTime macro crashing on form re-render after validation error

### DIFF
--- a/webapp/WEB-INF/templates/admin/util/calendar/macro_datetimepicker.html
+++ b/webapp/WEB-INF/templates/admin/util/calendar/macro_datetimepicker.html
@@ -97,7 +97,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 <script>
 document.addEventListener('DOMContentLoaded', function() {
 	<@getDateFormat format=format showFormat=showFormat time=true />
-	flatpickr('#${idField}', {enableTime: true, noCalendar:true, altInput:true, <#if time_24hr == true>time_24hr:true,</#if> altFormat: showFormat, dateFormat: dtFormat, "locale": "<@getLanguageInLocale language=language />"<#if defaultDate?has_content><#if defaultDate?is_datetime >, defaultDate : "${defaultDate?iso_local_nz}"<#else>, defaultDate : "${defaultDate?date?iso_local_nz}"</#if></#if><#if minTime !=''>, minTime : "${minTime?time("hh:mm")}"</#if><#if maxTime !=''>, maxTime : "${maxTime?time("hh:mm")}"</#if><#if minTime !=''>, minTime : "${minTime}"</#if><#if maxTime !=''>, maxTime : "${maxTime}"</#if>, ${setFlatPickerOptions( dateOptions )} });
+	flatpickr('#${idField}', {enableTime: true, noCalendar:true, altInput:true, <#if time_24hr == true>time_24hr:true,</#if> altFormat: showFormat, dateFormat: dtFormat, "locale": "<@getLanguageInLocale language=language />"<#if defaultDate?has_content><#if defaultDate?is_datetime >, defaultDate : "${defaultDate?iso_local_nz}"<#else>, defaultDate : "${defaultDate}"</#if></#if><#if minTime !=''>, minTime : "${minTime?time("hh:mm")}"</#if><#if maxTime !=''>, maxTime : "${maxTime?time("hh:mm")}"</#if><#if minTime !=''>, minTime : "${minTime}"</#if><#if maxTime !=''>, maxTime : "${maxTime}"</#if>, ${setFlatPickerOptions( dateOptions )} });
 });
 </script>
 </#macro>


### PR DESCRIPTION
Fixes Redmine [#32710](https://dev.lutece.paris.fr/bugtracker/issues/32710).

`macro_datetimepicker` getTime applied `?date` to a time-only value, throwing on form re-render after a validation error (500). Outputs the value as-is for the time picker.