### PR TITLE
LUT-32711 : Seed missing menu.translate.lang datastore key in init and upgrade SQL

### DIFF
--- a/src/sql/init_db_lutece_core.sql
+++ b/src/sql/init_db_lutece_core.sql
@@ -301,6 +301,7 @@ INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.user.themes.
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.user.themes.color.checkbox', '0');
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.user.themes.density.checkbox', '0');
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.logo.alt', '');
+INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.translate.lang', 'fr');
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.robotIndex.checkbox', '0');
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.xss.xssChars', '<>#"&');
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.xss.xssMsg', 'Les caract\\u00e8res &#60; &#62; &#35; et &#34;  &amp; sont interdits dans le contenu de votre message.');

--- a/src/sql/upgrade/update_db_lutece_core-8.0.1-8.0.2.sql
+++ b/src/sql/upgrade/update_db_lutece_core-8.0.1-8.0.2.sql
@@ -82,3 +82,7 @@ DELETE FROM core_datastore WHERE entity_key='portal.theme.site_property.menu.use
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.user.theme.switch.checkbox', '0');
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.user.themes.color.checkbox', '0');
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.user.themes.density.checkbox', '0');
+
+-- changeset core:update_db_lutece_core-8.0.1-8.0.2-rev3.sql
+DELETE FROM core_datastore WHERE entity_key='portal.theme.site_property.menu.translate.lang';
+INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.translate.lang', 'fr');


### PR DESCRIPTION
Fixes Redmine [#32711](https://dev.lutece.paris.fr/bugtracker/issues/32711).

`menu.translate.lang` was never seeded; `dskey()` returns the `DS Value Missing` sentinel, defeating the macro's `!'fr'` fallback and hiding the whole FO behind the `lang-translating` overlay. Seeds the key (`fr`) in init and in the 8.0.1-8.0.2 upgrade (new changeset) so migrated bases are healed too.