### PR TITLE
LUT-32752 : Fix datepicker bundle loaded twice in getThemeDatePicker

### DIFF
--- a/webapp/WEB-INF/templates/skin/themes/macros/components/datepicker/getThemeDatePicker.ftl
+++ b/webapp/WEB-INF/templates/skin/themes/macros/components/datepicker/getThemeDatePicker.ftl
@@ -45,11 +45,6 @@ Snippet:
 <@initThemeDatePicker />
 <#global themeDatepickerInitialized = true /></#if>
 <#local dtThemeOptions>${dskey('theme.site_property.config.datepicker.textblock')!}</#local>
-<#if isDatePickerLoaded?? && isDatePickerLoaded>
-<#else>
-<#global isDatePickerLoaded = true />
-<@initThemeDatePicker />
-</#if>
 <script>
 document.addEventListener('DOMContentLoaded', (e) => {
   const customOptions = {<#if options?size gt 0><#list options as opt, val>${opt} : <#if val?is_boolean || val?is_number>${val?c}<#elseif val?is_string>'${val}'</#if>,</#list></#if> };


### PR DESCRIPTION
The datepicker bundle was included twice (redundant init guard in getThemeDatePicker), causing the JS error `class themeDatepicker has already been declared`. Removed the redundant guard so it loads once.

Redmine: https://dev.lutece.paris.fr/bugtracker/issues/32752