### PR TITLE
LUT-32753 : Guard null formValidate/formValidateButton in cStepCurrent

### DIFF
--- a/webapp/WEB-INF/templates/skin/themes/macros/forms/steps/cStepCurrent.ftl
+++ b/webapp/WEB-INF/templates/skin/themes/macros/forms/steps/cStepCurrent.ftl
@@ -163,7 +163,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
 	const formValidate = document.getElementById('form-validate')<#if actionStep?? && actionStep !=''>,formValidateButton = document.getElementById('${actionStep!}')</#if>;
 	<#if step?number gt 1 >
 	<#if actionStep?? && actionStep !=''>
-	formValidateButton.addEventListener('click', (e) => {
+	formValidateButton && formValidateButton.addEventListener('click', (e) => {
 		const invalids = document.querySelectorAll('.form-control:invalid','.form-control:user-invalid');
 		const arrInvalids = Array.prototype.slice.call(invalids);
 		arrInvalids.forEach( function( invalid ){
@@ -204,7 +204,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
 	}
 
 	const btnValidateHidden = '<button class="visually-hidden" name="${actionStep}" aria-hidden="true" tabindex="-1" ></button>'
-	formValidate.insertAdjacentHTML('afterbegin', btnValidateHidden );
+	formValidate && formValidate.insertAdjacentHTML('afterbegin', btnValidateHidden );
 });
 </script> 
 <script type="module" src="${commonsSharedThemePath}${commonsSiteJsModulesPath}theme-form-validation.js"></script>


### PR DESCRIPTION
`cStepCurrent` dereferenced `formValidate` / `formValidateButton` without a null check, throwing on stepper pages that have no validate form. Added null guards before `addEventListener` / `insertAdjacentHTML`.

Redmine: https://dev.lutece.paris.fr/bugtracker/issues/32753