### PR TITLE
LUT-32754 : Guard 'DS Value Missing' sentinel in theme logo and colors

### DIFF
--- a/webapp/WEB-INF/templates/skin/themes/lutece/_theme.ftl
+++ b/webapp/WEB-INF/templates/skin/themes/lutece/_theme.ftl
@@ -39,7 +39,8 @@
 <#-- ---------------------------------- -->
 <#-- Theme Specific VARS                -->
 <#-- ---------------------------------- -->
-<#assign logoHeader>${dskey('portal.theme.site_property.menu.logo')!'${commonsSiteThemePath}images/logo.png'}</#assign>
+<#assign logoHeaderDS = dskey('portal.theme.site_property.menu.logo')!''>
+<#assign logoHeader><#if logoHeaderDS?has_content && !logoHeaderDS?starts_with('DS Value')>${logoHeaderDS}<#else>${commonsSiteThemePath}images/logo.png</#if></#assign>
 <#assign logoFooter>${dskey('portal.theme.site_property.layout.footer.logoFooter')!'${commonsSiteThemePath}images/logo.png'}</#assign>
 <#assign hasSearchMenu><#if !dskey('portal.theme.site_property.menu.search.checkbox')?starts_with('DS') &&  dskey('portal.theme.site_property.menu.search.checkbox') =='1'>true<#else>false</#if></#assign>
 <#assign footerLinkContact><#if dskey('portal.theme.site_property.Url.contactURL') !=''>${dskey('portal.theme.site_property.Url.contactURL')!'${urlMainSite}/contact'}</#if></#assign>

--- a/webapp/WEB-INF/templates/skin/themes/lutece/_theme_colors.ftl
+++ b/webapp/WEB-INF/templates/skin/themes/lutece/_theme_colors.ftl
@@ -1,19 +1,21 @@
 <#-- Main Colors Vars               -->
 <#-- Only override defined vars     -->
 <#-- Update ME IN BO                -->
+<#assign lightColors = dskey('theme.site_property.layout.colors.light.textblock')!''>
+<#assign darkColors = dskey('theme.site_property.layout.colors.dark.textblock')!''>
 <style>
 /*** 										***/
 /*** LIGHT Theme - Default					***/
 /*** 										***/
 [data-bs-theme=light] {
-${dskey('theme.site_property.layout.colors.light.textblock')!}
+<#if !lightColors?starts_with('DS Value')>${lightColors}</#if>
 }
 
 /*** 										***/
 /*** DARK Theme 							***/
 /*** 										***/
 [data-bs-theme=dark] {
-${dskey('theme.site_property.layout.colors.dark.textblock')!}
+<#if !darkColors?starts_with('DS Value')>${darkColors}</#if>
 }
 </style>
 <#-- End Update ME -->


### PR DESCRIPTION
`dskey()` returns the literal string `DS Value Missing` for absent datastore keys, so the `!'default'` operator never triggers: the logo emitted a 404 URL and theme colors emitted invalid CSS. Guarded both with `?starts_with('DS Value')`.

Redmine: https://dev.lutece.paris.fr/bugtracker/issues/32754