### PR TITLE
LUT-32790 : Move forms datastore seeds to new changeset rev4 to restore rev3 checksum

### DIFF
--- a/src/sql/upgrade/update_db_lutece_core-8.0.1-8.0.2.sql
+++ b/src/sql/upgrade/update_db_lutece_core-8.0.1-8.0.2.sql
@@ -86,6 +86,8 @@ INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.user.themes.
 -- changeset core:update_db_lutece_core-8.0.1-8.0.2-rev3.sql
 DELETE FROM core_datastore WHERE entity_key='portal.theme.site_property.menu.translate.lang';
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.menu.translate.lang', 'fr');
+
+-- changeset core:update_db_lutece_core-8.0.1-8.0.2-rev4.sql
 DELETE FROM core_datastore WHERE entity_key='portal.theme.site_property.forms.showResponseFormWarning.checkbox';
 INSERT INTO core_datastore VALUES ('portal.theme.site_property.forms.showResponseFormWarning.checkbox', '1');
 DELETE FROM core_datastore WHERE entity_key='portal.theme.site_property.forms.labelInfoResponse';


### PR DESCRIPTION
## Problem
Commit 1ac95eb9 (LUT-32055) appended datastore seeds to the **already-released** changeset `core:update_db_lutece_core-8.0.1-8.0.2-rev3.sql` instead of adding a new changeset. Its checksum changed, so Liquibase validation fails on every database that already ran rev3 (recette, prod):

```
liquibase.exception.ValidationFailedException: Validation Failed:
  update_db_lutece_core-8.0.1-8.0.2.sql::update_db_lutece_core-8.0.1-8.0.2-rev3.sql::core
  was: 9:9b1600b7825fe1e1a364ae43d8873375 but is now: 9:3ba17e5c4dce646d72f1d80743f7d820
```

## Fix
- Restore rev3 to its original content (`menu.translate.lang` only) so its checksum returns to the released value and already-migrated databases validate again.
- Move the added `forms.showResponseFormWarning.checkbox` / `forms.labelInfoResponse` seeds into a new changeset `rev4` (idempotent DELETE+INSERT) so they are applied everywhere.

Refs LUT-32790.
