### PR TITLE
LUT-33020-v8 : Fix ~3s blank page when default language datastore key is unset

### DIFF
--- a/webapp/WEB-INF/templates/skin/themes/macros/components/javascript/translation.ftl
+++ b/webapp/WEB-INF/templates/skin/themes/macros/components/javascript/translation.ftl
@@ -1,5 +1,10 @@
 <#function getDefaultLang>
 <#local defaultLang = dskey('portal.theme.site_property.menu.translate.lang')!'fr'>
+<#-- dskey may return the literal 'DS Value Missing' placeholder when the key is
+     not set, in which case the FreeMarker default (!'fr') does not apply. Guard
+     against it so the anti-flash logic in translationHead does not hide <body>
+     for the whole safety-net timeout on every load. -->
+<#if !defaultLang?has_content || defaultLang == 'DS Value Missing'><#local defaultLang = 'fr'></#if>
 <#return defaultLang>
 </#function>
 <#function getAllowedLangs>


### PR DESCRIPTION
## Problem

On a site where the default-language datastore property `portal.theme.site_property.menu.translate.lang` is not set, every page stays **blank for ~3 seconds** on load.

`getDefaultLang()` relies on the FreeMarker default operator (`!'fr'`), but `dskey(...)` returns the literal placeholder `DS Value Missing` (not `null`) when the key is unset, so the fallback never applies. The rendered `translationHead` inline script then contains `var defaultLang = 'DS Value Missing';`, which makes `pendingLang()` report a pending translation for **every** visitor. `<body>` is hidden via the `lang-translating` class, no Google Translate result ever arrives, and the page is only revealed by the 3s safety-net `setTimeout`.

## Fix

Guard `getDefaultLang()` so it falls back to `fr` when the datastore value is blank or equals the `DS Value Missing` placeholder.

## Notes

- Site-side workaround (no code): set `portal.theme.site_property.menu.translate.lang = fr`.
- Optional follow-up (not included here): reduce the safety-net timeout in `translationHead` from 3000ms to ~500ms.

Refs: bugtracker #33020