### PR TITLE
LUT-33119: Replace ?new class instantiation in the rich text editor templates with FreeMarker shared variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <dependency>
             <groupId>fr.paris.lutece.plugins</groupId>
             <artifactId>library-freemarker</artifactId>
-            <version>2.0.1</version>
+            <version>2.1.0-SNAPSHOT</version>
             <type>jar</type>            
         </dependency>
         <dependency>

--- a/src/java/fr/paris/lutece/portal/service/template/AppTemplateService.java
+++ b/src/java/fr/paris/lutece/portal/service/template/AppTemplateService.java
@@ -34,6 +34,8 @@
 package fr.paris.lutece.portal.service.template;
 
 import fr.paris.lutece.portal.service.datastore.DatastoreService;
+import fr.paris.lutece.portal.service.editor.RichTextEditorBackOfficeMethod;
+import fr.paris.lutece.portal.service.editor.RichTextEditorFrontOfficeMethod;
 import fr.paris.lutece.portal.service.i18n.I18nService;
 import fr.paris.lutece.portal.service.i18n.I18nTemplateMethod;
 import fr.paris.lutece.portal.service.plugin.Plugin;
@@ -75,6 +77,8 @@ public final class AppTemplateService
     	_context= context;
         _strTemplateDefaultPath = strTemplatePath;
         getFreeMarkerTemplateService(  ).setSharedVariable( "i18n", new I18nTemplateMethod( ) );
+        getFreeMarkerTemplateService(  ).setSharedVariable( "getFrontOfficeDefaultEditor", new RichTextEditorFrontOfficeMethod( ) );
+        getFreeMarkerTemplateService(  ).setSharedVariable( "getBackOfficeDefaultEditor", new RichTextEditorBackOfficeMethod( ) );
     }
 
     /**

--- a/webapp/WEB-INF/templates/admin/util/editor/editor.html
+++ b/webapp/WEB-INF/templates/admin/util/editor/editor.html
@@ -1,4 +1,4 @@
-<#assign textEditorName = "fr.paris.lutece.portal.service.editor.RichTextEditorBackOfficeMethod"?new()() >
+<#assign textEditorName = getBackOfficeDefaultEditor() >
 <#if textEditorName?has_content>
 	<#assign importUrl = "/admin/util/editor/editor_" + textEditorName + ".html">
 	<#include importUrl />

--- a/webapp/WEB-INF/templates/util/editor/editor.html
+++ b/webapp/WEB-INF/templates/util/editor/editor.html
@@ -1,4 +1,4 @@
-<#assign textEditorName = "fr.paris.lutece.portal.service.editor.RichTextEditorFrontOfficeMethod"?new()() >
+<#assign textEditorName = getFrontOfficeDefaultEditor() >
 <#if textEditorName?has_content>
 	<#assign importUrl = "/util/editor/editor_" + textEditorName + ".html">
 	<#include importUrl />


### PR DESCRIPTION
## Summary
Companion change to **LUT-33111** (FreeMarker SSTI hardening in `lutece-tech-library-freemarker`, which switches to `TemplateClassResolver.ALLOWS_NOTHING_RESOLVER` and disables the `?api` built-in).

The hardening forbids **any** `?new` class instantiation from templates. Two core templates still instantiated their rich text editor resolver via `?new` and would break at runtime (BO and FO WYSIWYG editor). They now use **shared variables** instead — same behaviour, no arbitrary instantiation.

## Changes
- `AppTemplateService.init()` — register both editor methods as shared variables (same pattern as the existing `i18n` shared variable):
  - `getFrontOfficeDefaultEditor` → `RichTextEditorFrontOfficeMethod`
  - `getBackOfficeDefaultEditor` → `RichTextEditorBackOfficeMethod`
- `webapp/WEB-INF/templates/util/editor/editor.html` (FO) — `?new()()` → `getFrontOfficeDefaultEditor()`
- `webapp/WEB-INF/templates/admin/util/editor/editor.html` (BO) — `?new()()` → `getBackOfficeDefaultEditor()`
- `pom.xml` — bump `library-freemarker` dependency `2.0.1` → `2.1.0-SNAPSHOT` (the hardened library)

## Scope check
Audit of all core templates: only these two files used `?new`; no template uses `?api`.

## Risk & Impact
- **Must be released together with LUT-33111** — the library hardening breaks the editor without this core change; this change is harmless with the old (SAFER) resolver.
- No end-user behaviour change; only the resolution mechanism differs.

## Test plan
- [ ] BO rich text editor renders and works
- [ ] FO rich text editor renders and works
- [ ] Editor-disabled case still falls back to the empty `initEditor` macro