### PR TITLE
LUT-32598 : Handle forbidden XSS characters in multipart requests (in…

### DIFF
--- a/src/java/fr/paris/lutece/portal/web/upload/UploadFilter.java
+++ b/src/java/fr/paris/lutece/portal/web/upload/UploadFilter.java
@@ -50,7 +50,7 @@ import org.apache.commons.fileupload.FileUploadBase.SizeLimitExceededException;
 import org.apache.commons.fileupload.FileUploadException;
 
 import fr.paris.lutece.portal.service.util.AppLogService;
-import fr.paris.lutece.portal.web.xss.XSSRequestWrapper;
+import fr.paris.lutece.portal.service.util.AppPropertiesService;
 import fr.paris.lutece.util.http.MultipartUtil;
 
 /**
@@ -60,6 +60,8 @@ public abstract class UploadFilter implements Filter
 {
     private static final String PROPERTY_TITLE_FILE_SIZE_LIMIT_EXCEEDED = "portal.util.message.titleDefault";
     private static final String PROPERTY_MESSAGE_FILE_SIZE_LIMIT_EXCEEDED = "portal.util.message.fileSizeLimitExceeded";
+    private static final String PROPERTY_SUFFIX_ACTIVATE_XSS_FILTER = ".activateXssFilter";
+    private static final String PROPERTY_SUFFIX_SANITIZE_FILTER_MODE = ".sanitizeFilterMode";
     private static final int KILO_BYTE = 1024;
     private static final String SIZE_THRESHOLD = "sizeThreshold";
     private static final String REQUEST_SIZE_MAX = "requestSizeMax";
@@ -67,6 +69,7 @@ public abstract class UploadFilter implements Filter
     private int _nSizeThreshold = -1;
     private long _nRequestSizeMax = -1;
     private boolean _bActivateNormalizeFileName;
+    private boolean _bXssSanitizeMode;
 
     /**
      * Forward the error message url depends site or admin implementation.
@@ -82,6 +85,14 @@ public abstract class UploadFilter implements Filter
      * @return Message
      */
     protected abstract String getMessageRelativeUrl( HttpServletRequest request, String strMessageKey, Object [ ] messageArgs, String strTitleKey );
+
+    /**
+     * Get the property prefix used to read the safe-request XSS configuration ({@code .activateXssFilter}, {@code .sanitizeFilterMode}) for this filter
+     * context (site or admin).
+     *
+     * @return the property prefix, without trailing dot
+     */
+    protected abstract String getSafeRequestPropertyPrefix( );
 
     /**
      * @see javax.servlet.Filter#init(javax.servlet.FilterConfig)
@@ -121,6 +132,22 @@ public abstract class UploadFilter implements Filter
             AppLogService.error( ex.getMessage( ), ex );
             throw new ServletException( ex.getMessage( ), ex );
         }
+
+        initXssSanitizeMode( );
+    }
+
+    /**
+     * Read the safe-request XSS configuration to determine whether the XSS filter is active in sanitize mode. Since this filter now runs before the safe
+     * request filter (see LUT-32598), the multipart body form fields must be sanitized at parse time : the safe request filter cannot wrap a
+     * {@link MultipartHttpServletRequest} without breaking downstream casts.
+     */
+    private void initXssSanitizeMode( )
+    {
+        String strPrefix = getSafeRequestPropertyPrefix( );
+        boolean bActivateXssFilter = Boolean.parseBoolean( AppPropertiesService.getProperty( strPrefix + PROPERTY_SUFFIX_ACTIVATE_XSS_FILTER ) );
+        boolean bSanitizeFilterMode = Boolean.parseBoolean( AppPropertiesService.getProperty( strPrefix + PROPERTY_SUFFIX_SANITIZE_FILTER_MODE ) );
+
+        _bXssSanitizeMode = bActivateXssFilter && bSanitizeFilterMode;
     }
 
     /**
@@ -151,7 +178,7 @@ public abstract class UploadFilter implements Filter
             {
         	
                 MultipartHttpServletRequest multiHtppRequest = MultipartUtil.convert( _nSizeThreshold, _nRequestSizeMax, _bActivateNormalizeFileName,
-                        httpRequest , httpRequest instanceof XSSRequestWrapper );
+                        httpRequest, _bXssSanitizeMode );
                 chain.doFilter( multiHtppRequest, response );
             }
             catch( SizeLimitExceededException e )

--- a/src/java/fr/paris/lutece/portal/web/upload/UploadFilterAdmin.java
+++ b/src/java/fr/paris/lutece/portal/web/upload/UploadFilterAdmin.java
@@ -44,6 +44,17 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class UploadFilterAdmin extends UploadFilter
 {
+    private static final String PROPERTY_SAFE_REQUEST_PREFIX = "lutece.safe.request.admin";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getSafeRequestPropertyPrefix( )
+    {
+        return PROPERTY_SAFE_REQUEST_PREFIX;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/java/fr/paris/lutece/portal/web/upload/UploadFilterSite.java
+++ b/src/java/fr/paris/lutece/portal/web/upload/UploadFilterSite.java
@@ -49,6 +49,17 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class UploadFilterSite extends UploadFilter
 {
+    private static final String PROPERTY_SAFE_REQUEST_PREFIX = "lutece.safe.request.site";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getSafeRequestPropertyPrefix( )
+    {
+        return PROPERTY_SAFE_REQUEST_PREFIX;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/java/fr/paris/lutece/portal/web/xss/SafeRequestFilter.java
+++ b/src/java/fr/paris/lutece/portal/web/xss/SafeRequestFilter.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.portal.web.xss;
 
+import fr.paris.lutece.portal.web.upload.MultipartHttpServletRequest;
 import fr.paris.lutece.util.http.SecurityUtil;
 
 import java.io.IOException;
@@ -109,21 +110,47 @@ public abstract class SafeRequestFilter implements Filter
     {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
 
-    	if ( _bActivateXssFilter && _bSanitizeFilterMode && request instanceof HttpServletRequest)
+    	if ( _bActivateXssFilter && _bSanitizeFilterMode && request instanceof HttpServletRequest && !( request instanceof MultipartHttpServletRequest ) )
     	{
     		chain.doFilter(new XSSRequestWrapper((HttpServletRequest) request), response);
-    	} 
-    	else if ( _bActivateXssFilter && _strXssCharacters != null && !_strXssCharacters.trim( ).equals( "" )
-                && !SecurityUtil.containsCleanParameters( httpRequest, _strXssCharacters ) )
+    	}
+    	else if ( _bActivateXssFilter && !_bSanitizeFilterMode && _strXssCharacters != null && !_strXssCharacters.trim( ).equals( "" )
+                && !hasCleanParameters( httpRequest ) )
         {
             HttpServletResponse httpServletResponse = (HttpServletResponse) response;
             httpServletResponse.sendRedirect( getMessageUrl( httpRequest, PROPERTY_REQUEST_PARAMETERS_CONTAINS_XSS_CHARACTERS, null,
                     PROPERTY_TITLE_REQUEST_PARAMETERS_CONTAINS_XSS_CHARACTERS ) );
-        } 
+        }
     	else
     	{
             chain.doFilter(request, response);
         }
+    }
+
+    /**
+     * Check that no request parameter contains forbidden XSS characters. The upload filter runs before this filter (see LUT-32598), so multipart requests are
+     * received as {@link MultipartHttpServletRequest} : their body form fields are scanned through the wrapper's own parameter accessors. Since the wrapper
+     * only exposes the multipart body form fields, the query string parameters are checked on the wrapped request.
+     *
+     * @param httpRequest
+     *            the HTTP request, possibly a {@link MultipartHttpServletRequest}
+     * @return true if no parameter contains forbidden XSS characters, false otherwise
+     */
+    private boolean hasCleanParameters( HttpServletRequest httpRequest )
+    {
+        if ( !SecurityUtil.containsCleanParameters( httpRequest, _strXssCharacters ) )
+        {
+            return false;
+        }
+
+        if ( httpRequest instanceof MultipartHttpServletRequest )
+        {
+            HttpServletRequest wrappedRequest = (HttpServletRequest) ( (MultipartHttpServletRequest) httpRequest ).getRequest( );
+
+            return SecurityUtil.containsCleanParameters( wrappedRequest, _strXssCharacters );
+        }
+
+        return true;
     }
 
     /**

--- a/src/test/java/fr/paris/lutece/util/http/SecurityUtilTest.java
+++ b/src/test/java/fr/paris/lutece/util/http/SecurityUtilTest.java
@@ -33,9 +33,16 @@
  */
 package fr.paris.lutece.util.http;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.fileupload.FileItem;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import fr.paris.lutece.portal.web.upload.MultipartHttpServletRequest;
 import fr.paris.lutece.test.LuteceTestCase;
 
 /**
@@ -83,6 +90,32 @@ public class SecurityUtilTest extends LuteceTestCase
         assertTrue( SecurityUtil.containsCleanParameters( request ) );
         request.setParameter( "param4", "}" );
         assertTrue( SecurityUtil.containsCleanParameters( request ) );
+    }
+
+    /**
+     * Test of containsCleanParameters method when the request is wrapped as a {@link MultipartHttpServletRequest}.
+     * Verifies that XSS characters are detected in the multipart body form-field parameters, which are scanned through
+     * the wrapper's own {@code getParameterNames()} / {@code getParameterValues()} methods rather than through the
+     * underlying request.
+     */
+    @Test
+    public void testContainsCleanParametersMultipart( )
+    {
+        System.out.println( "containsCleanParameters - multipart" );
+
+        Map<String, List<FileItem>> emptyFiles = Collections.emptyMap( );
+
+        MockHttpServletRequest underlying = new MockHttpServletRequest( );
+        Map<String, String [ ]> bodyParams = new HashMap<>( );
+        bodyParams.put( "bodyParam", new String [ ] { "az" } );
+        MultipartHttpServletRequest cleanRequest = new MultipartHttpServletRequest( underlying, emptyFiles, bodyParams );
+        assertTrue( SecurityUtil.containsCleanParameters( cleanRequest ) );
+
+        MockHttpServletRequest underlyingWithXssBody = new MockHttpServletRequest( );
+        Map<String, String [ ]> dirtyBodyParams = new HashMap<>( );
+        dirtyBodyParams.put( "bodyParam", new String [ ] { "<script>" } );
+        MultipartHttpServletRequest dirtyBodyRequest = new MultipartHttpServletRequest( underlyingWithXssBody, emptyFiles, dirtyBodyParams );
+        assertFalse( SecurityUtil.containsCleanParameters( dirtyBodyRequest ) );
     }
 
     /**

--- a/webapp/WEB-INF/web.xml
+++ b/webapp/WEB-INF/web.xml
@@ -117,9 +117,11 @@
         <filter-name>safeRequestFilterAdmin</filter-name>
         <filter-class>fr.paris.lutece.portal.web.xss.SafeRequestFilterAdmin</filter-class>
     </filter>
-    <!-- Many plugins cast request to MultipartHttpRequestServlet and request 
-        can be wrapped in any plugin's filter. So upload filters are processed after 
-        plugins'. See LUTECE-1323. requestSizeMax = the request size max activateNormalizeFileName 
+    <!-- Many plugins cast request to MultipartHttpRequestServlet and request
+        can be wrapped in any plugin's filter. So upload filters are processed after
+        plugins' but before the safe request (XSS) filters, so that the XSS filters can scan
+        the multipart body form fields. See LUTECE-1323 and LUT-32598. requestSizeMax = the
+        request size max activateNormalizeFileName
         = true if you want that the name of the files uploaded will be normalize -->
     <filter>
         <filter-name>uploadFilterSite</filter-name>
@@ -185,18 +187,10 @@
         <dispatcher>FORWARD</dispatcher>
         <dispatcher>REQUEST</dispatcher>
     </filter-mapping>
-  <filter-mapping>
-        <filter-name>safeRequestFilterSite</filter-name>
-        <url-pattern>/jsp/site/*</url-pattern>
-        <dispatcher>FORWARD</dispatcher>
-        <dispatcher>REQUEST</dispatcher>
-    </filter-mapping>
-    <filter-mapping>
-        <filter-name>safeRequestFilterAdmin</filter-name>
-        <url-pattern>/jsp/admin/*</url-pattern>
-        <dispatcher>FORWARD</dispatcher>
-        <dispatcher>REQUEST</dispatcher>
-    </filter-mapping>
+    <!-- Upload filters are mapped before the safe request (XSS) filters so that multipart requests
+        are converted to MultipartHttpServletRequest first : the XSS filters can then scan the
+        multipart body form fields through the wrapper's getParameterNames()/getParameterValues().
+        See LUT-32598. -->
     <filter-mapping>
         <filter-name>uploadFilterSite</filter-name>
         <url-pattern>/jsp/site/*</url-pattern>
@@ -205,6 +199,18 @@
     </filter-mapping>
     <filter-mapping>
         <filter-name>uploadFilterAdmin</filter-name>
+        <url-pattern>/jsp/admin/*</url-pattern>
+        <dispatcher>FORWARD</dispatcher>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>safeRequestFilterSite</filter-name>
+        <url-pattern>/jsp/site/*</url-pattern>
+        <dispatcher>FORWARD</dispatcher>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>safeRequestFilterAdmin</filter-name>
         <url-pattern>/jsp/admin/*</url-pattern>
         <dispatcher>FORWARD</dispatcher>
         <dispatcher>REQUEST</dispatcher>


### PR DESCRIPTION
…vert upload and xss filters order)

Map the upload filters before the safe request (XSS) filters in web.xml, so that multipart requests are converted to MultipartHttpServletRequest before the XSS check. The safe request filter can then scan the multipart body form fields through the wrapper's parameter accessors, and still checks the query string parameters on the wrapped request.

In sanitize mode, the multipart body form fields are sanitized at parse time by the upload filter (which now reads the safe request configuration itself), and the safe request filter no longer wraps MultipartHttpServletRequest instances to avoid breaking downstream casts (LUTECE-1323).