### PR TITLE
LUT-33169 : Cache the datastore keys that are missing

### DIFF
--- a/src/java/fr/paris/lutece/portal/business/datastore/DataEntityHome.java
+++ b/src/java/fr/paris/lutece/portal/business/datastore/DataEntityHome.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.portal.business.datastore;
 
+import fr.paris.lutece.portal.service.datastore.DatastoreService;
 import java.util.List;
 
 /**
@@ -60,6 +61,7 @@ public final class DataEntityHome
     public static DataEntity create( DataEntity entity )
     {
         _dao.insert( entity );
+        DatastoreService.evictCachedKey( entity.getKey( ) );
 
         return entity;
     }
@@ -76,7 +78,10 @@ public final class DataEntityHome
      */
     public static boolean createIfAbsent( DataEntity entity )
     {
-        return _dao.insertIfAbsent( entity );
+        boolean bCreated = _dao.insertIfAbsent( entity );
+        DatastoreService.evictCachedKey( entity.getKey( ) );
+
+        return bCreated;
     }
 
     /**
@@ -89,6 +94,7 @@ public final class DataEntityHome
     public static DataEntity update( DataEntity entity )
     {
         _dao.store( entity );
+        DatastoreService.evictCachedKey( entity.getKey( ) );
 
         return entity;
     }
@@ -102,6 +108,7 @@ public final class DataEntityHome
     public static void remove( String strKey )
     {
         _dao.delete( strKey );
+        DatastoreService.evictCachedKey( strKey );
     }
 
     // /////////////////////////////////////////////////////////////////////////

--- a/src/java/fr/paris/lutece/portal/service/datastore/DatastoreService.java
+++ b/src/java/fr/paris/lutece/portal/service/datastore/DatastoreService.java
@@ -63,8 +63,77 @@ public final class DatastoreService
     private static final String DATASTORE_KEY = "dskey";
     private static final Pattern PATTERN_DATASTORE_KEY = Pattern.compile( "#" + DATASTORE_KEY + "\\{(.*?)\\}" );
     static final String VALUE_MISSING = "DS Value Missing";
+    private static final DataEntity ENTITY_MISSING = new DataEntity( null, null );
     public static Lutece107Cache<String,DataEntity> _cache;
     private static boolean _bDatabase = true;
+
+    /**
+     * Tells whether the cache can be used
+     *
+     * @return true when the cache exists and is open
+     */
+    private static boolean isCacheUsable( )
+    {
+        return _cache != null && _cache.isCacheEnable( ) && !_cache.isClosed( );
+    }
+
+    /**
+     * Get an entity from the cache
+     *
+     * @param strKey
+     *            The entity's key
+     * @return The cached entity, the missing marker for a key known not to exist, null when the key
+     *         has not been looked up yet
+     */
+    private static DataEntity getCachedEntity( String strKey )
+    {
+        return isCacheUsable( ) ? _cache.get( strKey ) : null;
+    }
+
+    /**
+     * Put an entity in the cache
+     *
+     * @param strKey
+     *            The entity's key
+     * @param entity
+     *            The entity to cache, or the missing marker
+     */
+    private static void cacheEntity( String strKey, DataEntity entity )
+    {
+        if ( isCacheUsable( ) )
+        {
+            _cache.put( strKey, entity );
+        }
+    }
+
+    /**
+     * Drop a key from the cache, whether it held a value or the missing marker
+     *
+     * Called by DataEntityHome on every write so a caller that stores an entity through the home
+     * rather than through this service does not leave a stale entry behind.
+     *
+     * @param strKey
+     *            The entity's key
+     */
+    public static void evictCachedKey( String strKey )
+    {
+        if ( isCacheUsable( ) )
+        {
+            _cache.remove( strKey );
+        }
+    }
+
+    /**
+     * Tells whether a cached entity is the marker of a key known not to exist
+     *
+     * @param entity
+     *            The cached entity
+     * @return true for the missing marker, whose key is null while a stored row always has one
+     */
+    private static boolean isMissing( DataEntity entity )
+    {
+        return entity != null && entity.getKey( ) == null;
+    }
     
 
     /**
@@ -97,12 +166,7 @@ public final class DatastoreService
         {
             if ( _bDatabase )
             {
-                DataEntity entity = null;
-
-                if ( _cache != null && _cache.isCacheEnable() && !_cache.isClosed( ))
-                {
-                    entity =  _cache.get( strKey );
-                }
+                DataEntity entity = getCachedEntity( strKey );
 
                 if ( entity == null )
                 {
@@ -110,16 +174,13 @@ public final class DatastoreService
 
                     if ( entity == null )
                     {
-                        return strDefault;
+                        entity = ENTITY_MISSING;
                     }
 
-                    if ( _cache != null && _cache.isCacheEnable() && !_cache.isClosed( ))
-                    {
-                        _cache.put( strKey, entity );
-                    }
+                    cacheEntity( strKey, entity );
                 }
 
-                return entity.getValue( );
+                return isMissing( entity ) ? strDefault : entity.getValue( );
             }
         }
         catch( NoDatabaseException e )
@@ -166,11 +227,6 @@ public final class DatastoreService
                 if ( entity != null )
                 {
                     DataEntityHome.update( p );
-
-                    if ( _cache != null && _cache.isCacheEnable() && !_cache.isClosed( ))
-                    {
-                        _cache.remove( strKey );
-                    }
                 }
                 else
                 {
@@ -248,11 +304,6 @@ public final class DatastoreService
             if ( _bDatabase )
             {
                 DataEntityHome.remove( strKey );
-
-                if ( _cache != null && _cache.isCacheEnable() && !_cache.isClosed( ))
-                {
-                    _cache.remove( strKey );
-                }
             }
         }
         catch( NoDatabaseException e )
@@ -410,12 +461,7 @@ public final class DatastoreService
         {
             if ( _bDatabase )
             {
-                DataEntity entity = null;
-
-                if ( _cache != null && _cache.isCacheEnable() && !_cache.isClosed( ))
-                {
-                    entity =  _cache.get( strKey );
-                }
+                DataEntity entity = getCachedEntity( strKey );
 
                 if ( entity == null )
                 {
@@ -423,11 +469,13 @@ public final class DatastoreService
 
                     if ( entity == null )
                     {
-                        return false;
+                        entity = ENTITY_MISSING;
                     }
+
+                    cacheEntity( strKey, entity );
                 }
 
-                return true;
+                return !isMissing( entity );
             }
         }
         catch( NoDatabaseException e )

--- a/src/test/java/fr/paris/lutece/portal/service/datastore/DatastoreServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/datastore/DatastoreServiceTest.java
@@ -35,6 +35,8 @@ package fr.paris.lutece.portal.service.datastore;
 
 import org.junit.jupiter.api.Test;
 
+import fr.paris.lutece.portal.business.datastore.DataEntity;
+import fr.paris.lutece.portal.business.datastore.DataEntityHome;
 import fr.paris.lutece.test.LuteceTestCase;
 
 /**
@@ -43,8 +45,10 @@ import fr.paris.lutece.test.LuteceTestCase;
 public class DatastoreServiceTest extends LuteceTestCase
 {
     private static final String KEY1 = "key1";
+    private static final String KEY2 = "key2";
     private static final String VALUE_DEFAULT = "default";
     private static final String VALUE1 = "value1";
+    private static final String VALUE2 = "value2";
     @Test
     public void test( )
     {
@@ -54,5 +58,60 @@ public class DatastoreServiceTest extends LuteceTestCase
         strValue = DatastoreService.getDataValue( KEY1, VALUE_DEFAULT );
         assertEquals( strValue, VALUE1 );
         DatastoreService.removeData( KEY1 );
+    }
+
+    /**
+     * A key looked up while absent must still be seen once it is created, then once it is removed :
+     * the absent state is cached, so every write has to drop it.
+     */
+    @Test
+    public void testAbsentThenCreatedThenRemoved( )
+    {
+        assertEquals( VALUE_DEFAULT, DatastoreService.getDataValue( KEY2, VALUE_DEFAULT ) );
+        assertFalse( DatastoreService.existsKey( KEY2 ) );
+
+        DatastoreService.setDataValue( KEY2, VALUE2 );
+        assertTrue( DatastoreService.existsKey( KEY2 ) );
+        assertEquals( VALUE2, DatastoreService.getDataValue( KEY2, VALUE_DEFAULT ) );
+
+        DatastoreService.removeData( KEY2 );
+        assertFalse( DatastoreService.existsKey( KEY2 ) );
+        assertEquals( VALUE_DEFAULT, DatastoreService.getDataValue( KEY2, VALUE_DEFAULT ) );
+    }
+
+    /**
+     * A key stored through the home rather than through this service must still become visible,
+     * even when it was looked up while missing beforehand : the home drops the cached marker.
+     */
+    @Test
+    public void testCreatedThroughHomeAfterMiss( )
+    {
+        String strKey = "key4";
+        assertEquals( VALUE_DEFAULT, DatastoreService.getDataValue( strKey, VALUE_DEFAULT ) );
+
+        DataEntityHome.create( new DataEntity( strKey, VALUE1 ) );
+        assertEquals( VALUE1, DatastoreService.getDataValue( strKey, VALUE_DEFAULT ) );
+
+        DataEntityHome.update( new DataEntity( strKey, VALUE2 ) );
+        assertEquals( VALUE2, DatastoreService.getDataValue( strKey, VALUE_DEFAULT ) );
+
+        DataEntityHome.remove( strKey );
+        assertEquals( VALUE_DEFAULT, DatastoreService.getDataValue( strKey, VALUE_DEFAULT ) );
+    }
+
+    /**
+     * insertDataValueIfAbsent must expose the value it stored, even when the key was looked up and
+     * cached as absent beforehand.
+     */
+    @Test
+    public void testInsertIfAbsentAfterMiss( )
+    {
+        String strKey = "key3";
+        assertEquals( VALUE_DEFAULT, DatastoreService.getDataValue( strKey, VALUE_DEFAULT ) );
+        assertTrue( DatastoreService.insertDataValueIfAbsent( strKey, VALUE1 ) );
+        assertEquals( VALUE1, DatastoreService.getDataValue( strKey, VALUE_DEFAULT ) );
+        assertFalse( DatastoreService.insertDataValueIfAbsent( strKey, VALUE2 ) );
+        assertEquals( VALUE1, DatastoreService.getDataValue( strKey, VALUE_DEFAULT ) );
+        DatastoreService.removeData( strKey );
     }
 }


### PR DESCRIPTION
A key missing from core_datastore was queried again on every call: the lookup returned the default without caching anything. The default theme reads four such keys through dskey(), which cost 60 of the 75 statements of a front page render.

A missing key is now cached as a marker entity, recognisable by its null key since a stored row always has one. DataEntityHome drops the cached entry on every write, so a caller that stores an entity through the home rather than through DatastoreService does not leave a stale marker behind.