### PR TITLE
Add multilingual README support for zh-CN, ja, es

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 # What is Lutece?
 
+<!-- hy-mt2-i18n:start -->
+**English** · [中文](./README_zh-CN.md) · [日本語](./README_ja.md) · [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
 ![Lutece logo](https://github.com/lutece-platform/lutece-core/blob/develop/webapp/themes/skin/shared/images/Lutece-logo.png?raw=true)
 
 Lutece is an open platform that enables city governments to share, re-use and adapt digital services created by other cities. Lutece is free, modular and secure.

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,44 @@
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | [中文](./README_zh-CN.md) | [日本語](./README_ja.md) | **Español**
+<!-- hy-mt2-i18n:end -->
+
+![](https://dev.lutece.paris.fr/jenkins/buildStatus/icon?job=core-deploy)
+[![Alerta](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece%3Alutece-core&metric=alert_status)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece%3Alutece-core)
+[![Líneas de código](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece%3Alutece-core&metric=ncloc)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece%3Alutece-core)
+[![Cobertura](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece%3Alutece-core&metric=coverage)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece%3Alutece-core)
+
+# ¿Qué es Lutece?
+
+![Logotipo de Lutece](https://github.com/lutece-platform/lutece-core/blob/develop/webapp/themes/skin/shared/images/Lutece-logo.png?raw=true)
+
+Lutece es una plataforma abierta que permite a los gobiernos municipales compartir, reutilizar y adaptar servicios digitales creados por otras ciudades. Es gratuito, modular y seguro.
+
+A través de Lutece, descubra más de 400 módulos listos para usar que le permitirán potenciar sus servicios digitales y satisfacer las necesidades de los residentes.
+
+Puede personalizar y mejorar fácilmente los módulos para que se adapten a las necesidades de su ciudad, o crear módulos digitales desde cero y compartirlos nuevamente con la comunidad de Lutece.
+
+
+| Gratis| Modular| Seguro|
+|-----------------|-----------------|-----------------|
+| Lutece se basa en código abierto, lo que significa que su código fuente está disponible gratuitamente.| Lutece le permite personalizar uno de los 400 módulos listos para usar o crear los suyos propios para satisfacer sus necesidades específicas.| Lutece es una plataforma probada, estable y segura que es utilizada por organizaciones del sector público en todo el mundo.|
+
+
+# Información del proyecto
+
+ 
+* La página oficial de Lutece: [https://lutece.paris.fr](https://lutece.paris.fr)  
+* La [licencia del proyecto de código abierto](LICENSE)  
+* Documentación técnica en [Lutece WIKI](https://lutece.paris.fr/support/jsp/site/Portal.jsp?page=wiki)  
+*  [Lutece MOOC](https://mooc.lutece.paris.fr/): Este curso le enseñará todos los conceptos básicos del desarrollo con Lutece.  
+* La página de demostración de [Lutece](http://dev.lutece.paris.fr/site-demo/), disponible en línea (los datos se reinician cada 3 horas).  
+*  [Lutece docker hub](https://hub.docker.com/u/lutece): Imágenes integradas de Docker del proyecto.  
+*  [Repositorio de fuentes de la plataforma Lutece](https://github.com/lutece-platform/): El repositorio en línea para todos los complementos de Lutece.  
+*  [Repositorio de paquetes de la plataforma Lutece](https://dev.lutece.paris.fr/nexus/#view-repositories): El repositorio de paquetes para todos los complementos de Lutece.  
+*  [Seguimiento de problemas](https://dev.lutece.paris.fr/bugtracker/projects/lutece/issues): Sistema de gestión de problemas para este proyecto (se requiere autenticación).
+
+
+[Documentación e informes de Maven](https://dev.lutece.paris.fr/plugins/lutece-core/)
+
+
+
+ *Generado por [xdoc2md](https://github.com/lutece-platform/tools-maven-xdoc2md-plugin) – no lo edite directamente.*

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,44 @@
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | [中文](./README_zh-CN.md) | **日本語** | [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
+![](https://dev.lutece.paris.fr/jenkins/buildStatus/icon?job=core-deploy)
+[![Alerte](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece%3Alutece-core&metric=alert_status)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece%3Alutece-core)
+[![Line of code](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece%3Alutece-core&metric=ncloc)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece%3Alutece-core)
+[![Coverage](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece%3Alutece-core&metric=coverage)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece%3Alutece-core)
+
+# Luteceとは？
+
+![Luteceロゴ](https://github.com/lutece-platform/lutece-core/blob/develop/webapp/themes/skin/shared/images/Lutece-logo.png?raw=true)
+
+Luteceは、各都市政府が他の都市で作成されたデジタルサービスを共有し、再利用し、カスタマイズできるオープンプラットフォームです。Luteceは無料で、モジュール式かつセキュアです。
+
+Luteceを通じて、デジタルサービスの機能強化や住民のニーズへの対応に役立つ、400以上の既成モジュールをご活用いただけます。
+
+既存のモジュールを簡単にカスタマイズ・強化して自市のニーズに合わせたり、一から新しいデジタルモジュールを作成してLuteceコミュニティと共有することもできます。
+
+
+| 無料 | モジュール式 | 安全 |
+|-----------------|-----------------|-----------------|
+| Luteceはオープンソースを基盤としており、そのためソースコードが自由に利用可能です。| Luteceを使えば、400以上の既存モジュールから適切なものをカスタマイズしたり、独自のモジュールを作成してニーズに合わせたサービスを構築できます。| Luteceは実績のある安定性と安全性を備えたプラットフォームで、世界中の公共機関で採用されています。|
+
+
+# プロジェクト情報
+
+ 
+* 公式のLuteceサイト：[https://lutece.paris.fr](https://lutece.paris.fr)  
+* オープンソースの[プロジェクトライセンス](LICENSE)  
+* 技術ドキュメント [Lutece WIKI](https://lutece.paris.fr/support/jsp/site/Portal.jsp?page=wiki)  
+*  [Lutece MOOC](https://mooc.lutece.paris.fr/)：このコースではLuteceを使った開発の基礎をすべて学ぶことができます。  
+* オンラインの[Luteceデモサイト](http://dev.lutece.paris.fr/site-demo/)（データは3時間ごとにリセットされます）  
+*  [Lutece docker hub](https://hub.docker.com/u/lutece)：プロジェクト用のDocker内蔵イメージ  
+*  [Lutece platform Source Repository](https://github.com/lutece-platform/)：すべてのLuteceプラグインが格納されているオンラインリポジトリ  
+*  [Lutece platform Package Repository](https://dev.lutece.paris.fr/nexus/#view-repositories)：すべてのLuteceプラグイン用のパッケージリポジトリ  
+*  [Issue Tracking](https://dev.lutece.paris.fr/bugtracker/projects/lutece/issues)：このプロジェクト専用の問題管理システム（認証が必要）
+
+
+[Mavenのドキュメントとレポート](https://dev.lutece.paris.fr/plugins/lutece-core/)
+
+
+
+ *[xdoc2md](https://github.com/lutece-platform/tools-maven-xdoc2md-plugin)によって生成されています。直接編集しないでください。]*

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,0 +1,44 @@
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | **中文** | [日本語](./README_ja.md) | [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
+![](https://dev.lutece.paris.fr/jenkins/buildStatus/icon?job=core-deploy)
+[![警报状态](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece%3Alutece-core&metric=alert_status)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece%3Alutece-core)
+[![代码行数](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece%3Alutece-core&metric=ncloc)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece%3Alutece-core)
+[![代码覆盖率](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece%3Alutece-core&metric=coverage)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece%3Alutece-core)
+
+# 什么是 Lutece？
+
+![Lutece 徽标](https://github.com/lutece-platform/lutece-core/blob/develop/webapp/themes/skin/shared/images/Lutece-logo.png?raw=true)
+
+Lutece 是一个开放平台，让各城市政府能够共享、重复使用并改造其他城市开发的数字化服务。它兼具免费、模块化以及高安全性的特点。
+
+通过 Lutece，您可以找到400多种现成的模块，用于为您的数字服务提供支持并满足居民的需求。
+
+您可以轻松地对现有模块进行定制和优化，以满足所在城市的需求，或者从零开始创建新的数字模块，并将其分享回 Lutece 社区。
+
+
+| 免费| 模块化| 安全|
+|-----------------|-----------------|-----------------|
+| Lutece基于开源技术构建，因此其源代码可免费获取。| Lutece允许您定制400个现成模块中的任意一个，或根据自身需求创建专属模块。| Lutece是一个经过验证的稳定且安全的平台，被全球众多公共部门机构所采用。|
+
+
+# 项目信息
+
+ 
+* 官方 Lutece 网站：[https://lutece.paris.fr](https://lutece.paris.fr)  
+* 开源 [项目许可证](LICENSE)  
+* 技术文档 [Lutece WIKI](https://lutece.paris.fr/support/jsp/site/Portal.jsp?page=wiki)  
+*  [Lutece MOOC](https://mooc.lutece.paris.fr/)：该课程将为您讲解使用 Lutece 进行开发的全部基础知识。  
+* 在线的 [Lutece 演示网站](http://dev.lutece.paris.fr/site-demo/)（数据每3小时重置一次）  
+*  [Lutece docker hub](https://hub.docker.com/u/lutece)：该项目内置的 Docker 镜像  
+*  [Lutece 平台源代码仓库](https://github.com/lutece-platform/)：所有 Lutece 插件的在线存储库。  
+*  [Lutece 平台软件包仓库](https://dev.lutece.paris.fr/nexus/#view-repositories)：所有 Lutece 插件的软件包存储库。  
+*  [问题跟踪系统](https://dev.lutece.paris.fr/bugtracker/projects/lutece/issues)：该项目的issue管理工具（需要身份验证）。
+
+
+[Maven文档与报告](https://dev.lutece.paris.fr/plugins/lutece-core/)
+
+
+
+ *由[xdoc2md](https://github.com/lutece-platform/tools-maven-xdoc2md-plugin)生成——请勿直接编辑。*


### PR DESCRIPTION
## What this PR does

Adds README support for Simplified Chinese, Japanese, and Spanish so readers of those languages
can follow your project just as easily.

This is additive and opt-in: no existing content or code is changed, and the
new files are safe to close or delete at any time.

## Why we opened this PR

We're the team behind [Tencent Hunyuan MT (HY MT2)](https://github.com/Tencent-Hunyuan/Hy-MT2),
a translation model we recently open-sourced. We're using it to help open
source projects we appreciate reach readers in more languages.

We'd also love your feedback — both on the new READMEs in this PR and on the
[model](https://github.com/Tencent-Hunyuan/Hy-MT2#contact-us) itself.

## Scope of changes

**New README files (with language-switcher links)**

- README_zh-CN.md
- README_ja.md
- README_es.md

**Existing READMEs updated with language-switcher links only**

- README.md

That's the entire change: 4 files. Nothing else is touched.

> Worried about the upkeep? A separate companion PR can help keep these
> translations in sync automatically going forward — adopt it only if you
> want to.