### PR TITLE
Move Spring to 5.3.39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <jiraProjectName>LUTECE</jiraProjectName>
         <jiraComponentId>10000</jiraComponentId>
-        <springVersion>5.3.30</springVersion>
+        <springVersion>5.3.39</springVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.project>lutece-platform/lutece-core</github.project>
         <twitter.account>LuteceFoundry</twitter.account>


### PR DESCRIPTION
PR jumelle de [lutece-test-library-lutece-unit-testing#22](https://github.com/lutece-platform/lutece-test-library-lutece-unit-testing/pull/22). Les deux doivent partir ensemble.

### Le changement

`springVersion` passe de **5.3.30** à **5.3.39**. Une seule propriété pilote les huit artefacts déclarés ici — `spring-aop`, `beans`, `context`, `core`, `orm`, `tx`, `web`, `test` — et `spring-expression`, `spring-jdbc` et `spring-jcl` suivent transitivement.

### Pourquoi maintenant

`library-lutece-unit-testing` épinglait `spring-test` en **4.3.3.RELEASE**, une version de 2016. Comme c'est une dépendance de test **directe** de `lutece-site-pom`, son `spring-core` se retrouve plus près de la racine que celui atteint via la plateforme :

```
site
\- library-lutece-unit-testing:test
   \- spring-test:4.3.3.RELEASE:test
      \- spring-core:4.3.3.RELEASE:compile   (scope not updated to compile)

   toutes les autres voies :
   (spring-core:5.3.30:compile - omitted for conflict with 4.3.3.RELEASE)
```

Maven tranche sur la distance et non sur la version, puis laisse ce nœud en portée `compile` bien que son parent soit en `test`. Le jar était donc packagé dans le WAR et masquait le vrai `spring-core`. Les sites ne démarraient plus :

```
java.lang.NoSuchMethodError: org.springframework.util.ReflectionUtils.accessibleConstructor(...)
    at org.springframework.web.SpringServletContainerInitializer.onStartup
```

Méthode absente de `spring-core 4.3.3`, appelée par `spring-web 5.3` — vérifié au bytecode. `spring-jcl`, qui n'existe que depuis Spring 5, était par ailleurs totalement absent du WAR.

Maintenir le core et la bibliothèque de test sur la **même** version est ce qui écarte cette classe de conflit. `lutece-bom` ne gère aucun artefact Spring, rien ne l'arbitre autrement.

### Vérifications

`mvn clean compile` en JDK 11 : `BUILD SUCCESS`.

Résolution homogène, les onze artefacts en 5.3.39 et `spring-test` bien confiné :

```
spring-aop, beans, context, core, expression, jcl, jdbc, orm, tx, web : 5.3.39:compile
spring-test : 5.3.39:test
```

Suite complète, `mvn lutece:exploded antrun:run -Dlutece-test-hsql test` en JDK 11 :

```
[INFO] Tests run: 751, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

**Note sur un faux positif** : un premier `mvn clean test` sans cette mise en place remontait 749 erreurs, toutes en `LuteceTestCase.setUp:104 » NullPointer`. Contrôle fait en remettant le pom d'origine : `StringUtilTest` échouait à l'identique, 7 erreurs sur 7, avec 5.3.30. C'était l'absence d'environnement de test, pas une régression — la même classe passe 7/7 dans l'exécution correcte ci-dessus.

### Autres lignes

`origin/develop` est en `8.0.2-SNAPSHOT` et ne déclare plus de `springVersion` : la v8 n'utilise plus Spring, rien à y faire. `origin/develop7.1.x` est encore en **5.3.20** — à aligner aussi si cette ligne est encore maintenue.

