### PR TITLE
Parse the download URL without httpclient in FileServiceTest

### DIFF
--- a/src/test/java/fr/paris/lutece/portal/service/file/FileServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/file/FileServiceTest.java
@@ -37,9 +37,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
+import java.net.URLDecoder;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -48,8 +47,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.io.FileUtils;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import fr.paris.lutece.portal.business.file.File;
@@ -171,13 +168,8 @@ public class FileServiceTest extends LuteceTestCase
 	        String strUrl = FileService.getInstance( ).getFileStoreServiceProvider( ).getFileDownloadUrlBO( strFileId, data );
 	        assertNotNull( strUrl );
 	
-	        List<NameValuePair> params = URLEncodedUtils.parse( strUrl, Charset.forName( "UTF-8" ) );
-	
 	        MockHttpServletRequest request = new MockHttpServletRequest( );
-	        for ( NameValuePair param : params )
-	        {
-	            request.addParameter( param.getName( ), param.getValue( ) );
-	        }
+	        addUrlParameters( request, strUrl );
 	
 	        // add mock BO authentication
 	        registerAdminUserAdmin( request );
@@ -216,13 +208,8 @@ public class FileServiceTest extends LuteceTestCase
 	        String strUrl = FileService.getInstance( ).getFileStoreServiceProvider( ).getFileDownloadUrlFO( strFileId, data );
 	        assertNotNull( strUrl );
 	
-	        List<NameValuePair> params = URLEncodedUtils.parse( strUrl, Charset.forName( "UTF-8" ) );
-	
 	        MockHttpServletRequest request = new MockHttpServletRequest( );
-	        for ( NameValuePair param : params )
-	        {
-	            request.addParameter( param.getName( ), param.getValue( ) );
-	        }
+	        addUrlParameters( request, strUrl );
 	
 	        // no authentication
 	
@@ -242,6 +229,68 @@ public class FileServiceTest extends LuteceTestCase
      * 
      * @return a file
      */
+    /**
+     * Adds to the request the parameters of a download URL, the way
+     * URLEncodedUtils.parse( strUrl, UTF-8 ) used to before that class was dropped along
+     * with the httpclient dependency it came from.
+     *
+     * <p>
+     * The parsing looks odd because the string is not a query string : it is a whole URL,
+     * whose parameters UrlItem.getUrlWithEntity joins with the numeric entity
+     * <code>&amp;#38;</code>. Splitting it on both <code>&amp;</code> and <code>;</code>, the two
+     * separators URLEncodedUtils defaulted to, therefore yields three tokens for
+     * <code>&lt;url&gt;?provider=X&amp;#38;data=Y</code> : a first name carrying the path, a
+     * stray <code>#38</code>, and <code>data=Y</code>. Only the last one matters, the code
+     * under test reading everything it needs from the encrypted <code>data</code>. Splitting
+     * on <code>&amp;</code> alone would leave <code>#38;data</code> as the name and the test
+     * would fail.
+     * </p>
+     *
+     * @param request
+     *            The request to fill
+     * @param strUrl
+     *            The download URL
+     */
+    private static void addUrlParameters( MockHttpServletRequest request, String strUrl )
+    {
+        for ( String strToken : strUrl.split( "[&;]" ) )
+        {
+            if ( strToken.isEmpty( ) )
+            {
+                continue;
+            }
+
+            int nEquals = strToken.indexOf( '=' );
+
+            if ( nEquals < 0 )
+            {
+                // a token without '=' had a null value, which the request would reject
+                continue;
+            }
+
+            request.addParameter( decode( strToken.substring( 0, nEquals ) ), decode( strToken.substring( nEquals + 1 ) ) );
+        }
+    }
+
+    /**
+     * URL decodes a parameter name or value in UTF-8.
+     *
+     * @param strValue
+     *            The value to decode
+     * @return The decoded value
+     */
+    private static String decode( String strValue )
+    {
+        try
+        {
+            return URLDecoder.decode( strValue, "UTF-8" );
+        }
+        catch( UnsupportedEncodingException e )
+        {
+            throw new IllegalStateException( e );
+        }
+    }
+
     private File getOneLuteceFile( ) throws UnsupportedEncodingException
     {
         File file = new File( );


### PR DESCRIPTION
Répare la CI de `develop7.x`, en échec depuis `b7f3d582 "Update version from 7.0.6 to 7.0.8-SNAPSHOT"`.

> Version révisée : la première mouture déclarait une dépendance `httpclient` en portée test. Elle est remplacée par une réécriture en Java pur, qui supprime la dépendance au lieu de la déclarer. **Le `pom.xml` n'est plus touché du tout.**

### Le symptôme

```
FileServiceTest.java:[51,23] package org.apache.http does not exist
FileServiceTest.java:[52,36] package org.apache.http.client.utils does not exist
```

Échec en `testCompile`, donc les 751 tests ne tournaient même pas.

### La cause : une fuite transitive qui s'est refermée

`org.apache.http` n'a **jamais** été déclaré dans ce pom. Il arrivait par ricochet :

```
lutece-core
\- library-lutece-unit-testing:test
   \- nu.validator:validator:20.7.2:test
      +- httpclient:4.4:test        ← la seule source de org.apache.http
      \- httpcore:4.4:test
```

| global-pom | bibliothèque | `validator` optional | `org.apache.http` |
|---|---|---|---|
| **7.0.6** | 4.1.1 | non | propagé, la compilation passe |
| **7.0.8-SNAPSHOT** | 4.1.3-SNAPSHOT | **oui** | absent, la compilation casse |

Le passage en `optional` côté bibliothèque est volontaire et justifié : il empêche `httpclient 4.4` (2014) et `jetty 9.4.18` de fuir en portée compile dans tous les consommateurs, une fuite qui faisait échouer des webapps sur `NoSuchMethodError`. La conséquence n'avait pas été répercutée ici, et aucun global-pom ne gère `httpcomponents`.

### Le correctif

Le test n'utilisait `URLEncodedUtils.parse` que pour découper une query string en paramètres de requête. C'est désormais fait sur place, et **lutece-core ne dépend plus du tout de HttpComponents 4.x**.

Trois imports disparaissent — `NameValuePair`, `URLEncodedUtils` et `java.nio.charset.Charset`, devenu inutilisé.

### Attention au `[&;]`, ce n'est pas cosmétique

La chaîne n'est pas une query string mais une URL complète, dont `UrlItem.getUrlWithEntity` joint les paramètres avec l'**entité numérique** `&#38;` :

```java
return ( ( bFirst ) ? "?" : "&#38;" ) + _strName + "=" + _strValue;
```

Or `URLEncodedUtils.parse( String, Charset )` découpait sur deux séparateurs — vérifié au bytecode, `bipush 38` et `bipush 59`, soit `&` et `;`. Pour `<url>?provider=X&#38;data=Y`, cela donnait donc trois jetons :

| Jeton | Nom | Valeur |
|---|---|---|
| 1 | `<baseUrl>jsp/admin/file/download?provider` | `X` |
| 2 | `#38` | `null` |
| 3 | **`data`** | `Y` |

Seul le troisième compte : `getFileFromRequestBO` relit tout depuis le `data` chiffré, `getDataToEncrypt` y ayant empaqueté `file_id`, `resource_id` et `resource_type`. C'est le séparateur `;` qui détache le `#38` parasite — **un découpage sur `&` seul laisserait `#38;data` comme nom et le test échouerait**.

D'où la javadoc sur la méthode : sans elle, un relecteur « simplifierait » la classe de caractères et casserait le test.

### Vérifications

`mvn clean lutece:exploded antrun:run test -Dlutece-test-hsql` en JDK 11 :

```
[INFO] Tests run: 751, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`FileServiceTest` passe ses 5 tests. `git diff origin/develop7.x --stat` : un seul fichier, le test.

### La ligne v8 porte la même fragilité

`FileServiceTest` de `origin/develop` importe aussi `org.apache.http`, et le pom v8 ne déclare pas `httpcomponents`. Elle compile aujourd'hui parce que `validator` n'est pas encore `optional` dans la ligne v8 de la bibliothèque (5.0.1, épinglée par global-pom 8.0.1 et 8.0.2-SNAPSHOT). Le jour où elle recevra la même hygiène, la v8 cassera à l'identique. Le même correctif y est portable tel quel, sans rien ajouter au pom.
