### PR TITLE
Drop the commons-httpclient test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,18 +82,6 @@
             <artifactId>commons-fileupload</artifactId>
             <version>1.5</version>
         </dependency>
-       <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-	    </exclusions>
-            <scope>test</scope>
-         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/src/test/java/fr/paris/lutece/portal/web/upload/UploadServletTest.java
+++ b/src/test/java/fr/paris/lutece/portal/web/upload/UploadServletTest.java
@@ -34,6 +34,7 @@
 package fr.paris.lutece.portal.web.upload;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,11 +43,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.httpclient.methods.PostMethod;
-import org.apache.commons.httpclient.methods.multipart.ByteArrayPartSource;
-import org.apache.commons.httpclient.methods.multipart.FilePart;
-import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
-import org.apache.commons.httpclient.methods.multipart.Part;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -227,24 +223,37 @@ public class UploadServletTest extends LuteceTestCase
         PluginService.notifyListeners( new PluginEvent( p, PluginEvent.PLUGIN_INSTALLED ) );
     }
 
+    /**
+     * Builds a request holding a raw multipart/form-data body with one file part, the way
+     * commons-httpclient 3.1 did before that dependency was dropped. What is under test does not
+     * change : UploadServlet and commons-fileupload still parse a real multipart body, and the
+     * Content-Type header still carries the MIME boundary, which is what makes that parsing possible.
+     * 
+     * @return The request
+     * @throws Exception
+     *             If the body cannot be written
+     */
     private MockHttpServletRequest getMultipartRequest( ) throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest( );
         byte [ ] fileContent = new byte [ ] {
                 1, 2, 3
         };
-        Part [ ] parts = new Part [ ] {
-                new FilePart( "file1", new ByteArrayPartSource( "file1", fileContent ) )
-        };
-        MultipartRequestEntity multipartRequestEntity = new MultipartRequestEntity( parts, new PostMethod( ).getParams( ) );
-        // Serialize request body
+
+        // fixed rather than random, as the library used to generate it : the body stays reproducible
+        String strBoundary = "----LuteceUploadServletTestBoundary";
+
         ByteArrayOutputStream requestContent = new ByteArrayOutputStream( );
-        multipartRequestEntity.writeRequest( requestContent );
-        // Set request body to HTTP servlet request
+        requestContent.write( ( "--" + strBoundary + "\r\n" + "Content-Disposition: form-data; name=\"file1\"; filename=\"file1\"\r\n"
+                + "Content-Type: application/octet-stream\r\n\r\n" ).getBytes( StandardCharsets.US_ASCII ) );
+        requestContent.write( fileContent );
+        requestContent.write( ( "\r\n--" + strBoundary + "--\r\n" ).getBytes( StandardCharsets.US_ASCII ) );
+
         request.setContent( requestContent.toByteArray( ) );
-        // Set content type to HTTP servlet request (important, includes Mime boundary string)
-        request.setContentType( multipartRequestEntity.getContentType( ) );
+        // important, the boundary is what lets commons-fileupload split the body
+        request.setContentType( "multipart/form-data; boundary=" + strBoundary );
         request.setMethod( "POST" );
+
         return request;
     }
 }


### PR DESCRIPTION
> **À fusionner après #824.** Sa CI restera rouge jusque-là : `develop7.x` porte encore le `FileServiceTest` que #824 répare, et la compilation des tests s'arrête avant d'atteindre celui-ci. Rien à voir avec le contenu de cette PR — voir la vérification plus bas.

### Pourquoi la retirer

`commons-httpclient 3.1` date de 2007 et sa ligne est abandonnée en amont depuis 2011, avec des advisories connues — dont l'absence de vérification du nom d'hôte TLS.

En portée `test`, elle n'est **pas** dangereuse : jamais packagée, ne fuit pas vers les plugins consommateurs, ne masque aucune autre version. Mais elle remonte dans chaque scan de dépendances, et le reste de cette ligne a déjà migré : `library-httpaccess` utilise `httpclient5:5.1.3`.

### Son unique utilisateur

`UploadServletTest.getMultipartRequest`, qui ne s'en servait que pour deux choses : fabriquer un corps `multipart/form-data` contenant un fichier, et relire le `Content-Type` correspondant.

```java
Part [ ] parts = new Part [ ] { new FilePart( "file1", new ByteArrayPartSource( "file1", fileContent ) ) };
MultipartRequestEntity multipartRequestEntity = new MultipartRequestEntity( parts, new PostMethod( ).getParams( ) );
multipartRequestEntity.writeRequest( requestContent );
request.setContentType( multipartRequestEntity.getContentType( ) );
```

Les deux sont maintenant écrites sur place, en une douzaine de lignes.

### Ce qui ne change pas

`UploadServlet` et commons-fileupload analysent toujours un **corps multipart brut**, et le `Content-Type` porte toujours la frontière MIME — c'est elle qui rend ce découpage possible.

La frontière devient **fixe** au lieu d'être tirée au hasard par la bibliothèque, donc le corps est reproductible d'une exécution à l'autre.

### Une voie écartée

`MockMultipartHttpServletRequest` de spring-test aurait supprimé la dépendance en trois lignes, mais elle fournit une requête **déjà analysée** : elle court-circuiterait précisément ce que ce test vérifie.

### Vérifications

Le pom ne contient plus aucune occurrence de `commons-httpclient`, il reste bien formé, et `grep -rn "org.apache.commons.httpclient" src/` ne remonte plus que la mention en javadoc qui explique l'historique.

La suite complète a été passée avec le correctif de #824 appliqué localement par-dessus, puisque c'est l'état qu'aura `develop7.x` après sa fusion :

```
[INFO] Tests run: 751, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`UploadServletTest` passe ses 4 tests. Le correctif temporaire a ensuite été retiré : cette branche ne contient que `pom.xml` et `UploadServletTest.java`, elle ne touche pas `FileServiceTest`.

### Après ces deux PR

lutece-core ne dépendra plus d'aucun client HTTP historique — ni HttpComponents 4.x, ni Commons HttpClient 3.x.
