### PR TITLE
Parse the download URL without httpclient in FileServiceTest (core8)

### DIFF
--- a/src/test/java/fr/paris/lutece/portal/service/file/FileServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/file/FileServiceTest.java
@@ -37,15 +37,12 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
+import java.net.URLDecoder;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.junit.jupiter.api.Test;
 
 import fr.paris.lutece.portal.business.file.File;
@@ -219,13 +216,8 @@ public class FileServiceTest extends LuteceTestCase
             String strUrl = _fileServiceProvider.getFileDownloadUrlBO( strFileId, data );
             assertNotNull( strUrl );
 
-            List<NameValuePair> params = URLEncodedUtils.parse( strUrl, Charset.forName( "UTF-8" ) );
-
             MockHttpServletRequest request = new MockHttpServletRequest( );
-            for ( NameValuePair param : params )
-            {
-                request.addParameter( param.getName( ), param.getValue( ) );
-            }
+            addUrlParameters( request, strUrl );
 
             // add mock BO authentication
             registerAdminUserAdmin( request );
@@ -265,13 +257,8 @@ public class FileServiceTest extends LuteceTestCase
             String strUrl = _fileServiceProvider.getFileDownloadUrlFO( strFileId, data );
             assertNotNull( strUrl );
 
-            List<NameValuePair> params = URLEncodedUtils.parse( strUrl, Charset.forName( "UTF-8" ) );
-
             MockHttpServletRequest request = new MockHttpServletRequest( );
-            for ( NameValuePair param : params )
-            {
-                request.addParameter( param.getName( ), param.getValue( ) );
-            }
+            addUrlParameters( request, strUrl );
 
             // no authentication
 
@@ -291,6 +278,68 @@ public class FileServiceTest extends LuteceTestCase
      * 
      * @return a file
      */
+    /**
+     * Adds to the request the parameters of a download URL, the way
+     * URLEncodedUtils.parse( strUrl, UTF-8 ) used to before that class was dropped along with
+     * the httpclient dependency it came from.
+     *
+     * <p>
+     * The parsing looks odd because the string is not a query string : it is a whole URL, whose
+     * parameters UrlItem.getUrlWithEntity joins with the numeric entity <code>&amp;#38;</code>.
+     * Splitting it on both <code>&amp;</code> and <code>;</code>, the two separators
+     * URLEncodedUtils defaulted to, therefore yields three tokens for
+     * <code>&lt;url&gt;?provider=X&amp;#38;data=Y</code> : a first name carrying the path, a stray
+     * <code>#38</code>, and <code>data=Y</code>. Only the last one matters, the code under test
+     * reading everything it needs from the encrypted <code>data</code>. Splitting on
+     * <code>&amp;</code> alone would leave <code>#38;data</code> as the name and the test would
+     * fail.
+     * </p>
+     *
+     * @param request
+     *            The request to fill
+     * @param strUrl
+     *            The download URL
+     */
+    private static void addUrlParameters( MockHttpServletRequest request, String strUrl )
+    {
+        for ( String strToken : strUrl.split( "[&;]" ) )
+        {
+            if ( strToken.isEmpty( ) )
+            {
+                continue;
+            }
+
+            int nEquals = strToken.indexOf( '=' );
+
+            if ( nEquals < 0 )
+            {
+                // a token without '=' had a null value, which the request would reject
+                continue;
+            }
+
+            request.addParameter( decode( strToken.substring( 0, nEquals ) ), decode( strToken.substring( nEquals + 1 ) ) );
+        }
+    }
+
+    /**
+     * URL decodes a parameter name or value in UTF-8.
+     *
+     * @param strValue
+     *            The value to decode
+     * @return The decoded value
+     */
+    private static String decode( String strValue )
+    {
+        try
+        {
+            return URLDecoder.decode( strValue, "UTF-8" );
+        }
+        catch( UnsupportedEncodingException e )
+        {
+            throw new IllegalStateException( e );
+        }
+    }
+
     private File getOneLuteceFile( ) throws UnsupportedEncodingException
     {
         File file = new File( );


### PR DESCRIPTION
Portage sur la ligne v8 du correctif de [#824](https://github.com/lutece-platform/lutece-core/pull/824).

> **Cette ligne n'est pas cassée aujourd'hui.** C'est un correctif **préventif**, contrairement à #824 qui répare une CI rouge.

### La fragilité

`FileServiceTest` importe `org.apache.http`, et ce pom ne déclare **aucun** artefact `httpcomponents`. Le package arrive par une fuite transitive :

```
lutece-core
\- library-lutece-unit-testing:test
   \- nu.validator:validator:20.7.2:test
      +- httpclient:test        ← la seule source de org.apache.http
      \- httpcore:test
```

Cela ne fonctionne que parce que `validator` est une dépendance transitive ordinaire dans la ligne v8 de cette bibliothèque, la 5.0.1 — épinglée par global-pom 8.0.1 et 8.0.2-SNAPSHOT.

Sa ligne v7 la marque `optional`, délibérément, pour empêcher `httpclient 4.4` (2014) et `jetty 9.4.18` de fuir en portée compile dans tous les consommateurs — une fuite qui faisait échouer des webapps sur `NoSuchMethodError`. **Le jour où la même hygiène atteindra cette ligne, la compilation des tests cassera exactement comme en v7.**

### Le correctif

Le test n'utilisait `URLEncodedUtils.parse` que pour découper une query string en paramètres de requête. C'est désormais fait sur place : la ligne ne repose plus sur une dépendance non déclarée, et **le `pom.xml` n'est pas touché**.

Quatre imports disparaissent : `NameValuePair`, `URLEncodedUtils`, `java.nio.charset.Charset` et `java.util.List`, tous devenus inutilisés.

### Attention au `[&;]`, ce n'est pas cosmétique

La chaîne n'est pas une query string mais une URL complète, dont `UrlItem.getUrlWithEntity` joint les paramètres avec l'**entité numérique** `&#38;` :

```java
return ( ( bFirst ) ? "?" : "&#38;" ) + _strName + "=" + _strValue;
```

Or `URLEncodedUtils.parse( String, Charset )` découpait sur ces deux séparateurs — vérifié au bytecode, `bipush 38` et `bipush 59`. Pour `<url>?provider=X&#38;data=Y`, cela donnait trois jetons :

| Jeton | Nom | Valeur |
|---|---|---|
| 1 | `<baseUrl>jsp/admin/file/download?provider` | `X` |
| 2 | `#38` | `null` |
| 3 | **`data`** | `Y` |

Seul le troisième compte : le code sous test relit tout depuis le `data` chiffré. C'est le séparateur `;` qui détache le `#38` parasite — **un découpage sur `&` seul laisserait `#38;data` comme nom et le test échouerait**. D'où la javadoc sur la méthode, pour qu'un relecteur ne « simplifie » pas la classe de caractères.

### Écarts avec le portage v7

- cette ligne utilise le mock Lutece, `fr.paris.lutece.test.mocks.MockHttpServletRequest`, dont `addParameter( String, String )` a la même forme — vérifié au bytecode ;
- `UnsupportedEncodingException` est **conservé**, d'autres méthodes du fichier le déclarant ;
- l'indentation de ces blocs diffère, en espaces seulement.

### Vérifications

`mvn clean lutece:exploded antrun:run test -Dlutece-test-hsql` en JDK 17 :

```
[INFO] Tests run: 710, Failures: 0, Errors: 0, Skipped: 1
[INFO] BUILD SUCCESS
```

`FileServiceTest` passe ses **6 tests**.

L'unique test ignoré est `FileHomeTransactionTest`, sans lien avec ce changement : il porte un `@Disabled( "requires an active JTA transaction : no JTA provider in the unit-test harness" )` préexistant.

