### PR TITLE
Tell a property declared without a value from a missing one in AppPathService

### DIFF
--- a/src/java/fr/paris/lutece/portal/service/util/AppPathService.java
+++ b/src/java/fr/paris/lutece/portal/service/util/AppPathService.java
@@ -75,6 +75,7 @@ public final class AppPathService
 {
     public static final String SESSION_BASE_URL = "base_url";
     private static final String MSG_LOG_PROPERTY_NOT_FOUND = "Property {0} not found in the properties file ";
+    private static final String MSG_LOG_PROPERTY_EMPTY = "Property {0} is declared with an empty value in the properties file, which the configuration API resolves as undefined. Set a value, or remove the declaration if the setting is optional. ";
     private static final int PORT_NUMBER_HTTP = 80;
     private static final String PROPERTY_BASE_URL = "lutece.base.url";
     private static final String PROPERTY_PORTAL_URL = "lutece.portal.path";
@@ -791,14 +792,30 @@ public final class AppPathService
 
         if ( strDirectory == null )
         {
-            Object [ ] propertyMissing = {
-                    strKey
-            };
-            String strMsg = MessageFormat.format( MSG_LOG_PROPERTY_NOT_FOUND, propertyMissing );
-            throw new AppException( strMsg );
+            throw new AppException( getUndefinedPropertyMessage( strKey ) );
         }
 
         return strDirectory;
+    }
+
+    /**
+     * Builds the diagnostic for a property key that {@link AppPropertiesService#getProperty(String) getProperty} resolved to <code>null</code>.
+     *
+     * The configuration API maps a key declared with an empty value to <code>null</code>, exactly as it maps a key that is absent altogether, so the resolved
+     * value alone cannot tell the two apart : only {@link AppPropertiesService#isPropertyDeclared(String) isPropertyDeclared} can.
+     *
+     * @param strKey
+     *            the property key that could not be resolved
+     * @return the message explaining why the key could not be resolved
+     */
+    private static String getUndefinedPropertyMessage( String strKey )
+    {
+        String strPattern = AppPropertiesService.isPropertyDeclared( strKey ) ? MSG_LOG_PROPERTY_EMPTY : MSG_LOG_PROPERTY_NOT_FOUND;
+        Object [ ] propertyKey = {
+                strKey
+        };
+
+        return MessageFormat.format( strPattern, propertyKey );
     }
 
     private static String getRealPath( String relativePath ) throws ResourceNotFoundException

--- a/src/java/fr/paris/lutece/portal/service/util/AppPropertiesService.java
+++ b/src/java/fr/paris/lutece/portal/service/util/AppPropertiesService.java
@@ -197,4 +197,21 @@ public final class AppPropertiesService
     {
         return StreamSupport.stream(_config.getPropertyNames().spliterator(), false).filter(key -> key.startsWith(strPrefix)).collect(Collectors.toList());
     }
+
+    /**
+     * Tells whether a property is declared by one of the configuration sources, whatever its value.
+     *
+     * {@link #getProperty(String)} resolves a property declared with an empty value to <code>null</code>, exactly as it resolves a property that no source
+     * declares, so the resolved value alone cannot tell the two apart. The property names known to the configuration do include the keys declared with an
+     * empty value, which makes this the only way to distinguish an empty declaration from a missing one.
+     *
+     * @param strProperty
+     *            the property key
+     * @return <code>true</code> if a configuration source declares the key, <code>false</code> otherwise
+     * @since version 8.0
+     */
+    public static boolean isPropertyDeclared( String strProperty )
+    {
+        return StreamSupport.stream(_config.getPropertyNames().spliterator(), false).anyMatch(key -> key.equals(strProperty));
+    }
 }

--- a/src/test/java/fr/paris/lutece/portal/service/util/AppPathServiceTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/util/AppPathServiceTest.java
@@ -53,6 +53,9 @@ public class AppPathServiceTest extends LuteceTestCase
     private static final String PROPERTY_VIRTUAL_HOST_KEY_PARAMETER = "virtualHostKey.parameterName";
     private static final String PROPERTY_BASE_URL = "lutece.base.url";
     private static final String FRAGMENT_END_PATH_CONF = "/WEB-INF/conf/";
+    // Declared in webapp/WEB-INF/conf/config.properties, with no value
+    private static final String PROPERTY_DECLARED_WITHOUT_VALUE = "lutece.prod.url";
+    private static final String PROPERTY_MISSING = "lutece.path.that.is.not.declared";
 
    
     /**
@@ -85,6 +88,33 @@ public class AppPathServiceTest extends LuteceTestCase
         {
             is.close( );
         }
+    }
+
+    /**
+     * A key declared with an empty value resolves to null just like an absent key, so getPath used to report both as not found. The exception must now name the
+     * actual cause, an empty declaration being fixed in a different place than a missing one.
+     */
+    @Test
+    public void testGetPathWhenPropertyIsDeclaredWithoutValue( )
+    {
+        assertNull( AppPropertiesService.getProperty( PROPERTY_DECLARED_WITHOUT_VALUE ) );
+        assertTrue( AppPropertiesService.isPropertyDeclared( PROPERTY_DECLARED_WITHOUT_VALUE ),
+                "The key must be known to the configuration even without a value" );
+
+        AppException e = assertThrows( AppException.class, ( ) -> AppPathService.getPath( PROPERTY_DECLARED_WITHOUT_VALUE ) );
+        assertTrue( e.getMessage( ).contains( "declared with an empty value" ), e.getMessage( ) );
+    }
+
+    /**
+     * Test of getPath method with a key that no configuration source declares.
+     */
+    @Test
+    public void testGetPathWhenPropertyIsMissing( )
+    {
+        assertFalse( AppPropertiesService.isPropertyDeclared( PROPERTY_MISSING ) );
+
+        AppException e = assertThrows( AppException.class, ( ) -> AppPathService.getPath( PROPERTY_MISSING ) );
+        assertTrue( e.getMessage( ).contains( "not found in the properties file" ), e.getMessage( ) );
     }
 
     /**


### PR DESCRIPTION
Portage sur la ligne v8 de #827 (`develop7.x`).

## Problème

`AppPathService.getRelativePath` conclut « propriété absente » sur le seul test de la valeur résolue :

```java
String strDirectory = AppPropertiesService.getProperty( strKey );

if ( strDirectory == null )
{
    ... MSG_LOG_PROPERTY_NOT_FOUND    // "Property {0} not found in the properties file"
}
```

Or `AppPropertiesService.getProperty` est `getOptionalValue( ... ).orElse( null )`, et l'API de configuration résout une valeur vide comme *undefined*. Une clé **déclarée sans valeur** et une clé **qu'aucune source ne déclare** arrivent donc toutes les deux à `null`, et produisent le même message.

Les deux se corrigent à des endroits différents — renseigner la valeur d'un côté, ajouter la déclaration de l'autre — donc le message envoie sur une fausse piste dans le cas vide.

## Correctif

`AppPropertiesService.isPropertyDeclared( String )` : les noms de propriétés connus de la configuration incluent les clés déclarées sans valeur, la présence est donc testable indépendamment de la valeur résolue. La méthode est posée dans le service de properties plutôt que chez l'appelant, tout consommateur confronté à la même ambiguïté pouvant la réutiliser.

`getRelativePath` choisit alors entre les deux diagnostics, le libellé existant restant inchangé pour une clé réellement absente. Seule différence avec la v7 : l'émission a migré de `getPath` vers `getRelativePath`, le correctif suit.

## Vérification

`mvn clean lutece:exploded antrun:run -Dlutece-test-hsql test -Dtest=AppPathServiceTest` sous JDK 17 → **6 tests, 0 échec**, dont deux nouveaux cas qui couvrent chaque branche. `lutece.prod.url` sert de fixture pour la déclaration vide, le `config.properties` du core la livrant ainsi.

Les deux messages tels que le build les émet :

```
ERROR lutece.application : Critical AppException, root cause: AppException: Property lutece.path.that.is.not.declared not found in the properties file
ERROR lutece.application : Critical AppException, root cause: AppException: Property lutece.prod.url is declared with an empty value in the properties file, which the configuration API resolves as undefined. Set a value, or remove the declaration if the setting is optional.
```

## Notes

- Aucune signature existante modifiée, le comportement ne change que sur le texte de l'exception.
- `@since version 8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)