### PR TITLE
LUT-33311 : AccountLifeTimeDaemon resynchronizes the account life time from the last login date

### DIFF
--- a/src/java/fr/paris/lutece/portal/business/user/AdminUserDAO.java
+++ b/src/java/fr/paris/lutece/portal/business/user/AdminUserDAO.java
@@ -110,6 +110,7 @@ public class AdminUserDAO implements IAdminUserDAO
     private static final String SQL_UPDATE_ANONYMIZATION_STATUS_USER_FILED = "UPDATE core_admin_user_anonymize_field  SET anonymize = ? WHERE field_name = ? ";
     private static final String SQL_QUERY_SELECT_EXPIRED_USER_ID = "SELECT id_user FROM core_admin_user WHERE status = ?";
     private static final String SQL_QUERY_SELECT_EXPIRED_LIFE_TIME_USER_ID = "SELECT id_user FROM core_admin_user WHERE account_max_valid_date < ? and status < ? ";
+    private static final String SQL_QUERY_SELECT_USERS_LIFE_TIME_TO_RESYNC = "SELECT id_user, status, account_max_valid_date, last_login FROM core_admin_user WHERE account_max_valid_date IS NOT NULL AND account_max_valid_date < ? AND status <= ? ";
     private static final String SQL_QUERY_SELECT_USER_ID_FIRST_ALERT = "SELECT id_user FROM core_admin_user WHERE nb_alerts_sent = 0 and status < ? and account_max_valid_date < ? ";
     private static final String SQL_QUERY_SELECT_USER_ID_OTHER_ALERT = "SELECT id_user FROM core_admin_user "
             + "WHERE nb_alerts_sent > 0 and nb_alerts_sent <= ? and status < ? and (account_max_valid_date + nb_alerts_sent * ?) < ? ";
@@ -1178,6 +1179,34 @@ public class AdminUserDAO implements IAdminUserDAO
         }
 
         return listIdExpiredUser;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<AdminUser> getUsersWithLifeTimeToResync( Timestamp maxValidDate )
+    {
+        List<AdminUser> listUsers = new ArrayList<>( );
+        try ( DAOUtil daoUtil = new DAOUtil( SQL_QUERY_SELECT_USERS_LIFE_TIME_TO_RESYNC ) )
+        {
+            daoUtil.setLong( 1, maxValidDate.getTime( ) );
+            daoUtil.setInt( 2, AdminUser.EXPIRED_CODE );
+
+            daoUtil.executeQuery( );
+
+            while ( daoUtil.next( ) )
+            {
+                AdminUser user = new AdminUser( );
+                user.setUserId( daoUtil.getInt( 1 ) );
+                user.setStatus( daoUtil.getInt( 2 ) );
+                user.setAccountMaxValidDate( new Timestamp( daoUtil.getLong( 3 ) ) );
+                user.setDateLastLogin( daoUtil.getTimestamp( 4 ) );
+                listUsers.add( user );
+            }
+        }
+
+        return listUsers;
     }
 
     /**

--- a/src/java/fr/paris/lutece/portal/business/user/AdminUserHome.java
+++ b/src/java/fr/paris/lutece/portal/business/user/AdminUserHome.java
@@ -533,6 +533,20 @@ public final class AdminUserHome
     }
 
     /**
+     * Get the users whose account life time may have to be resynchronized from their last login date : users with a not null account max valid date lower
+     * than the given date, and whose status is active, not active or expired. Only the id, the status, the account max valid date and the last login date of
+     * the returned users are set.
+     * 
+     * @param maxValidDate
+     *            The maximum account valid date of the users to return
+     * @return the list of users, with only their id, status, account max valid date and last login date set
+     */
+    public static List<AdminUser> getUsersWithLifeTimeToResync( Timestamp maxValidDate )
+    {
+        return _dao.getUsersWithLifeTimeToResync( maxValidDate );
+    }
+
+    /**
      * Get the list of id of users that need to receive their first alert
      * 
      * @param firstAlertMaxDate

--- a/src/java/fr/paris/lutece/portal/business/user/IAdminUserDAO.java
+++ b/src/java/fr/paris/lutece/portal/business/user/IAdminUserDAO.java
@@ -405,6 +405,17 @@ public interface IAdminUserDAO
     List<Integer> getIdUsersWithExpiredLifeTimeList( Timestamp currentTimestamp );
 
     /**
+     * Get the users whose account life time may have to be resynchronized from their last login date : users with a not null account max valid date lower
+     * than the given date, and whose status is active, not active or expired (anonymized users are ignored). Only the id, the status, the account max valid
+     * date and the last login date of the returned users are set.
+     * 
+     * @param maxValidDate
+     *            The maximum account valid date of the users to return
+     * @return the list of users, with only their id, status, account max valid date and last login date set
+     */
+    List<AdminUser> getUsersWithLifeTimeToResync( Timestamp maxValidDate );
+
+    /**
      * Get the list of id of users that need to receive their first alert
      * 
      * @param alertMaxDate

--- a/src/java/fr/paris/lutece/portal/service/admin/AdminAuthenticationService.java
+++ b/src/java/fr/paris/lutece/portal/service/admin/AdminAuthenticationService.java
@@ -159,7 +159,7 @@ public final class AdminAuthenticationService
                     {
                         unregisterUser( request );
                         registerUser( request, newUser );
-                        AdminUserService.updateDateLastLogin( user.getUserId( ) );
+                        AdminUserService.updateDateLastLogin( newUser.getUserId( ) );
 
                         // Start a new session
                         throw new UserNotSignedException( );

--- a/src/java/fr/paris/lutece/portal/service/admin/AdminUserService.java
+++ b/src/java/fr/paris/lutece/portal/service/admin/AdminUserService.java
@@ -1134,14 +1134,27 @@ public final class AdminUserService
      */
     public static Timestamp getAccountMaxValidDate( )
     {
+        return getAccountMaxValidDate( new Timestamp( new Date( ).getTime( ) ) );
+    }
+
+    /**
+     * Compute the maximum valid date of an account from a given date and the parameters in the database.
+     * 
+     * @param dateFrom
+     *            The date from which the account life time is counted (for example the last login date of the user)
+     * @return The maximum valid date of an account, or null if the account life time is not set or if dateFrom is null
+     */
+    public static Timestamp getAccountMaxValidDate( Timestamp dateFrom )
+    {
         int nbMonthsAccountValid = getIntegerSecurityParameter( DSKEY_ACCOUNT_LIFE_TIME );
 
-        if ( nbMonthsAccountValid <= 0 )
+        if ( ( nbMonthsAccountValid <= 0 ) || ( dateFrom == null ) )
         {
             return null;
         }
 
         Calendar calendar = new GregorianCalendar( LocaleService.getDefault( ) );
+        calendar.setTimeInMillis( dateFrom.getTime( ) );
         calendar.add( Calendar.MONTH, nbMonthsAccountValid );
 
         return new Timestamp( calendar.getTimeInMillis( ) );

--- a/src/java/fr/paris/lutece/portal/service/daemon/AccountLifeTimeDaemon.java
+++ b/src/java/fr/paris/lutece/portal/service/daemon/AccountLifeTimeDaemon.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.portal.service.daemon;
 
 import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -67,6 +68,8 @@ public class AccountLifeTimeDaemon extends Daemon
     private static final String MESSAGE_EXPIRED = "No expired passwords";
     private static final String MESSAGE_NO_NOTIF = "Expired passwords notification deactivated, skipping";
     private static final String MESSAGE_EXPIRED_USER = "No expired admin user found";
+    private static final String MESSAGE_NO_RESYNC = "No account life time to resynchronize from last login";
+    private static final String MESSAGE_RESYNC_DISABLED = "Account life time not set, skipping resynchronization from last login";
     private static final String PARAMETER_TIME_BEFORE_ALERT_ACCOUNT = "time_before_alert_account";
     private static final String PARAMETER_NB_ALERT_ACCOUNT = "nb_alert_account";
     private static final String PARAMETER_TIME_BETWEEN_ALERTS_ACCOUNT = "time_between_alerts_account";
@@ -99,7 +102,10 @@ public class AccountLifeTimeDaemon extends Daemon
         StringBuilder sbResult = new StringBuilder( );
         Timestamp currentTimestamp = new Timestamp( new java.util.Date( ).getTime( ) );
 
-        // We first set as expirated user that have reached their life time limit
+        // We first resynchronize the life time of the accounts whose expiration date is reached or close, from their last login date
+        runResyncAccountLifeTime( currentTimestamp, sbResult );
+
+        // We then set as expirated user that have reached their life time limit
         runSetExpiredUser( currentTimestamp, sbResult );
 
         // We send first alert to users
@@ -112,6 +118,76 @@ public class AccountLifeTimeDaemon extends Daemon
         runExpiredPassword( currentTimestamp, sbResult );
 
         setLastRunLogs( sbResult.toString( ) );
+    }
+
+    /**
+     * Resynchronize the account max valid date of the users from their last login date. The max valid date stored in database is only extended by the
+     * default authentication module : with an external authentication module (SSO, LDAP...) only the last login date is updated, so active users would
+     * expire. For each user whose stored max valid date is reached or will be reached before the first alert is sent, the max valid date is recomputed as
+     * last login date + account life time. If this new date is in the future, it is stored, the alerts counter is reset and the user is reactivated if
+     * the daemon had expired it. Users that never logged in or that did not log in for more than the account life time are not modified and expire
+     * normally.
+     * 
+     * @param currentTimestamp
+     *            The current time
+     * @param sbResult
+     *            The daemon logs
+     */
+    private void runResyncAccountLifeTime( Timestamp currentTimestamp, StringBuilder sbResult )
+    {
+        int nbMonthsAccountValid = AdminUserService.getIntegerSecurityParameter( AdminUserService.DSKEY_ACCOUNT_LIFE_TIME );
+
+        if ( nbMonthsAccountValid <= 0 )
+        {
+            AppLogService.info( MESSAGE_LOG_DAEMON_NAME, MESSAGE_RESYNC_DISABLED );
+            sbResult.append( MESSAGE_DAEMON_NAME + MESSAGE_RESYNC_DISABLED + "\n" );
+            return;
+        }
+
+        long nbDaysBeforeFirstAlert = Math.max( 0L, AdminUserService.getIntegerSecurityParameter( AdminUserService.DSKEY_TIME_BEFORE_ALERT_ACCOUNT ) );
+        Timestamp maxValidDate = new Timestamp( currentTimestamp.getTime( ) + DateUtil.convertDaysInMiliseconds( nbDaysBeforeFirstAlert ) );
+        List<AdminUser> listUsers = AdminUserHome.getUsersWithLifeTimeToResync( maxValidDate );
+        List<Integer> listIdReactivatedUsers = new ArrayList<>( );
+        int nbResyncedUsers = 0;
+
+        for ( AdminUser user : listUsers )
+        {
+            Timestamp newMaxValidDate = AdminUserService.getAccountMaxValidDate( user.getDateLastLogin( ) );
+
+            if ( ( newMaxValidDate != null ) && newMaxValidDate.after( currentTimestamp ) && newMaxValidDate.after( user.getAccountMaxValidDate( ) ) )
+            {
+                AdminUserHome.updateUserExpirationDate( user.getUserId( ), newMaxValidDate );
+                nbResyncedUsers++;
+
+                if ( user.getRealStatus( ) == AdminUser.EXPIRED_CODE )
+                {
+                    listIdReactivatedUsers.add( user.getUserId( ) );
+                }
+            }
+        }
+
+        if ( !listIdReactivatedUsers.isEmpty( ) )
+        {
+            AdminUserHome.updateUserStatus( listIdReactivatedUsers, AdminUser.ACTIVE_CODE );
+        }
+
+        if ( nbResyncedUsers > 0 )
+        {
+            StringBuilder sbLogs = new StringBuilder( );
+            sbLogs.append( MESSAGE_DAEMON_NAME );
+            sbLogs.append( nbResyncedUsers );
+            sbLogs.append( " account(s) life time resynchronized from last login, " );
+            sbLogs.append( listIdReactivatedUsers.size( ) );
+            sbLogs.append( " expired account(s) reactivated" );
+            AppLogService.info( "runResyncAccountLifeTime: {}", sbLogs );
+            sbResult.append( sbLogs.toString( ) );
+            sbResult.append( "\n" );
+        }
+        else
+        {
+            AppLogService.info( MESSAGE_LOG_DAEMON_NAME, MESSAGE_NO_RESYNC );
+            sbResult.append( MESSAGE_DAEMON_NAME + MESSAGE_NO_RESYNC + "\n" );
+        }
     }
 
     private void runSetExpiredUser( Timestamp currentTimestamp, StringBuilder sbResult )

--- a/src/java/fr/paris/lutece/portal/web/user/AdminUserJspBean.java
+++ b/src/java/fr/paris/lutece/portal/web/user/AdminUserJspBean.java
@@ -990,6 +990,7 @@ public class AdminUserJspBean extends AdminFeaturesPageJspBean
             user.setAccessibilityMode( strAccessibilityMode != null );
 
             AdminUserHome.update( user, PasswordUpdateMode.IGNORE );
+            renewLifeTimeOfReactivatedAccount( userToModify, nStatus );
 
             AdminUserFieldService.doModifyUserFields( user, request, getLocale( ), getUser( ) );
 
@@ -1018,6 +1019,7 @@ public class AdminUserJspBean extends AdminFeaturesPageJspBean
             }
 
             AdminUserHome.update( user );
+            renewLifeTimeOfReactivatedAccount( userToModify, user.getStatus( ) );
 
             AdminUserFieldService.doModifyUserFields( user, request, getLocale( ), getUser( ) );
 
@@ -1026,6 +1028,23 @@ public class AdminUserJspBean extends AdminFeaturesPageJspBean
         }
 
         return JSP_MANAGE_USER;
+    }
+
+    /**
+     * Renew the account life time of a user that an administrator reactivates after the account has expired. Without it, the account max valid date would
+     * remain in the past and the account life time daemon would expire the account again on its next run.
+     * 
+     * @param userBeforeModification
+     *            The user as it was before the modification
+     * @param nNewStatus
+     *            The new status of the user
+     */
+    private void renewLifeTimeOfReactivatedAccount( AdminUser userBeforeModification, int nNewStatus )
+    {
+        if ( ( userBeforeModification.getRealStatus( ) == AdminUser.EXPIRED_CODE ) && ( nNewStatus == AdminUser.ACTIVE_CODE ) )
+        {
+            AdminUserHome.updateUserExpirationDate( userBeforeModification.getUserId( ), AdminUserService.getAccountMaxValidDate( ) );
+        }
     }
 
     /**

--- a/src/test/java/fr/paris/lutece/portal/service/daemon/AccountLifeTimeDaemonTest.java
+++ b/src/test/java/fr/paris/lutece/portal/service/daemon/AccountLifeTimeDaemonTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2002-2026, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.portal.service.daemon;
+
+import java.security.SecureRandom;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Collections;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import fr.paris.lutece.portal.business.user.AdminUser;
+import fr.paris.lutece.portal.business.user.AdminUserHome;
+import fr.paris.lutece.portal.business.user.authentication.LuteceDefaultAdminAuthentication;
+import fr.paris.lutece.portal.business.user.authentication.LuteceDefaultAdminUser;
+import fr.paris.lutece.portal.service.admin.AdminUserService;
+import fr.paris.lutece.portal.service.datastore.DatastoreService;
+import fr.paris.lutece.test.LuteceTestCase;
+import fr.paris.lutece.util.password.IPasswordFactory;
+import jakarta.inject.Inject;
+
+/**
+ * Tests of the resynchronization of the account life time from the last login date by {@link AccountLifeTimeDaemon}
+ */
+public class AccountLifeTimeDaemonTest extends LuteceTestCase
+{
+    private static final int ACCOUNT_LIFE_TIME_MONTHS = 6;
+    private static final long ONE_DAY_MILLIS = 24L * 60L * 60L * 1000L;
+
+    @Inject
+    private IPasswordFactory _passwordFactory;
+
+    private LuteceDefaultAdminUser _user;
+    private String _strPreviousLifeTime;
+    private String _strPreviousTimeBeforeAlert;
+
+    @BeforeEach
+    public void setUp( ) throws Exception
+    {
+        _strPreviousLifeTime = getDatastoreValue( AdminUserService.DSKEY_ACCOUNT_LIFE_TIME );
+        _strPreviousTimeBeforeAlert = getDatastoreValue( AdminUserService.DSKEY_TIME_BEFORE_ALERT_ACCOUNT );
+        DatastoreService.setDataValue( AdminUserService.DSKEY_ACCOUNT_LIFE_TIME, Integer.toString( ACCOUNT_LIFE_TIME_MONTHS ) );
+        DatastoreService.setDataValue( AdminUserService.DSKEY_TIME_BEFORE_ALERT_ACCOUNT, "0" );
+
+        String strRandomUsername = "user" + new SecureRandom( ).nextLong( );
+        _user = new LuteceDefaultAdminUser( strRandomUsername, new LuteceDefaultAdminAuthentication( ) );
+        _user.setPassword( _passwordFactory.getPasswordFromCleartext( strRandomUsername ) );
+        _user.setFirstName( strRandomUsername );
+        _user.setLastName( strRandomUsername );
+        // no email : the daemon must not try to send alerts to this user
+        _user.setEmail( "" );
+        AdminUserHome.create( _user );
+    }
+
+    @AfterEach
+    public void tearDown( ) throws Exception
+    {
+        AdminUserHome.remove( _user.getUserId( ) );
+        AdminUserHome.removeAllPasswordHistoryForUser( _user.getUserId( ) );
+        restoreDatastoreValue( AdminUserService.DSKEY_ACCOUNT_LIFE_TIME, _strPreviousLifeTime );
+        restoreDatastoreValue( AdminUserService.DSKEY_TIME_BEFORE_ALERT_ACCOUNT, _strPreviousTimeBeforeAlert );
+    }
+
+    @Test
+    public void testActiveAccountWithRecentLoginIsResyncedInsteadOfExpired( )
+    {
+        Timestamp lastLogin = monthsAgo( 1 );
+        setAccountState( AdminUser.ACTIVE_CODE, daysAgo( 1 ), lastLogin );
+
+        new AccountLifeTimeDaemon( ).run( );
+
+        AdminUser user = AdminUserHome.findByPrimaryKey( _user.getUserId( ) );
+        assertEquals( AdminUser.ACTIVE_CODE, user.getRealStatus( ) );
+        assertEquals( AdminUserService.getAccountMaxValidDate( lastLogin ), user.getAccountMaxValidDate( ) );
+        assertTrue( user.getAccountMaxValidDate( ).after( new Timestamp( System.currentTimeMillis( ) ) ) );
+    }
+
+    @Test
+    public void testExpiredAccountWithRecentLoginIsReactivated( )
+    {
+        Timestamp lastLogin = monthsAgo( 1 );
+        setAccountState( AdminUser.EXPIRED_CODE, daysAgo( 1 ), lastLogin );
+
+        new AccountLifeTimeDaemon( ).run( );
+
+        AdminUser user = AdminUserHome.findByPrimaryKey( _user.getUserId( ) );
+        assertEquals( AdminUser.ACTIVE_CODE, user.getRealStatus( ) );
+        assertEquals( AdminUserService.getAccountMaxValidDate( lastLogin ), user.getAccountMaxValidDate( ) );
+    }
+
+    @Test
+    public void testAccountThatNeverLoggedInExpires( )
+    {
+        Timestamp maxValidDate = daysAgo( 1 );
+        setAccountState( AdminUser.ACTIVE_CODE, maxValidDate, AdminUser.getDefaultDateLastLogin( ) );
+
+        new AccountLifeTimeDaemon( ).run( );
+
+        AdminUser user = AdminUserHome.findByPrimaryKey( _user.getUserId( ) );
+        assertEquals( AdminUser.EXPIRED_CODE, user.getRealStatus( ) );
+        assertEquals( maxValidDate, user.getAccountMaxValidDate( ) );
+    }
+
+    @Test
+    public void testInactiveAccountExpires( )
+    {
+        Timestamp maxValidDate = daysAgo( 1 );
+        setAccountState( AdminUser.ACTIVE_CODE, maxValidDate, monthsAgo( ACCOUNT_LIFE_TIME_MONTHS + 1 ) );
+
+        new AccountLifeTimeDaemon( ).run( );
+
+        AdminUser user = AdminUserHome.findByPrimaryKey( _user.getUserId( ) );
+        assertEquals( AdminUser.EXPIRED_CODE, user.getRealStatus( ) );
+        assertEquals( maxValidDate, user.getAccountMaxValidDate( ) );
+    }
+
+    @Test
+    public void testNoResyncWhenAccountLifeTimeIsNotSet( )
+    {
+        DatastoreService.setDataValue( AdminUserService.DSKEY_ACCOUNT_LIFE_TIME, "0" );
+        Timestamp maxValidDate = daysAgo( 1 );
+        setAccountState( AdminUser.ACTIVE_CODE, maxValidDate, monthsAgo( 1 ) );
+
+        new AccountLifeTimeDaemon( ).run( );
+
+        AdminUser user = AdminUserHome.findByPrimaryKey( _user.getUserId( ) );
+        assertEquals( maxValidDate, user.getAccountMaxValidDate( ) );
+        assertEquals( AdminUser.EXPIRED_CODE, user.getRealStatus( ) );
+    }
+
+    @Test
+    public void testAccountWithFutureDateIsNotModified( )
+    {
+        Timestamp maxValidDate = new Timestamp( System.currentTimeMillis( ) + ( 30L * ONE_DAY_MILLIS ) );
+        setAccountState( AdminUser.ACTIVE_CODE, maxValidDate, monthsAgo( 1 ) );
+
+        new AccountLifeTimeDaemon( ).run( );
+
+        AdminUser user = AdminUserHome.findByPrimaryKey( _user.getUserId( ) );
+        assertEquals( AdminUser.ACTIVE_CODE, user.getRealStatus( ) );
+        assertEquals( maxValidDate, user.getAccountMaxValidDate( ) );
+    }
+
+    private void setAccountState( int nStatus, Timestamp maxValidDate, Timestamp lastLogin )
+    {
+        AdminUserHome.updateUserExpirationDate( _user.getUserId( ), maxValidDate );
+        AdminUserHome.updateDateLastLogin( _user.getUserId( ), lastLogin );
+        AdminUserHome.updateUserStatus( Collections.singletonList( _user.getUserId( ) ), nStatus );
+    }
+
+    private static Timestamp daysAgo( int nDays )
+    {
+        return new Timestamp( System.currentTimeMillis( ) - ( nDays * ONE_DAY_MILLIS ) );
+    }
+
+    private static Timestamp monthsAgo( int nMonths )
+    {
+        Calendar calendar = Calendar.getInstance( );
+        calendar.add( Calendar.MONTH, -nMonths );
+        return new Timestamp( calendar.getTimeInMillis( ) );
+    }
+
+    private static String getDatastoreValue( String strKey )
+    {
+        return DatastoreService.existsKey( strKey ) ? DatastoreService.getDataValue( strKey, null ) : null;
+    }
+
+    private static void restoreDatastoreValue( String strKey, String strValue )
+    {
+        if ( strValue == null )
+        {
+            DatastoreService.removeData( strKey );
+        }
+        else
+        {
+            DatastoreService.setDataValue( strKey, strValue );
+        }
+    }
+}


### PR DESCRIPTION
Redmine: https://dev.lutece.paris.fr/bugtracker/issues/33311

## Problem

With an external authentication module (`plugin-adminauthenticationwsso`, LDAP...), only `last_login` is updated at login: `account_max_valid_date` is never extended, so `AccountLifeTimeDaemon` expires active accounts (`status = 5`) exactly N months after their creation. When an administrator reactivates such an account, the date is not recomputed and the daemon expires it again on its next run.

## Changes

- **AccountLifeTimeDaemon**: new step `runResyncAccountLifeTime` executed before expiring accounts. For each account whose stored date is reached or will be reached before the first alert, the date is recomputed as `last_login + account life time`. If it is in the future it is stored, the alerts counter is reset and the account is reactivated if the daemon had expired it. Accounts that never logged in or that are inactive for more than the life time still expire. Number of resynced accounts is logged.
- **AdminUserJspBean**: renew the account life time when an administrator sets an expired account back to active.
- **AdminAuthenticationService**: update `last_login` of the new user, not the previous one, when the SSO user changes within the same HTTP session.
- **AdminUserService**: `getAccountMaxValidDate( Timestamp )` overload.
- **AdminUserDAO / AdminUserHome / IAdminUserDAO**: `getUsersWithLifeTimeToResync( Timestamp )`.
- **AccountLifeTimeDaemonTest**: 6 cases (resync of an active account, reactivation of an expired account, never logged in, inactive, life time not set, future date untouched).

## Tests

- `AccountLifeTimeDaemonTest` and the existing `AdminUser*Test`, `AdminLoginJspBeanTest`, `ImportAdminUserServiceTest` pass (133 tests).
- Verified on a local site (Open Liberty): five accounts in the expected states before a daemon run, then reactivation of an expired account from the back-office.